### PR TITLE
Add inverted backlog filter to Chalk Planning work context

### DIFF
--- a/tests/dont_filter_edit_test.py
+++ b/tests/dont_filter_edit_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from helpers.label_helpers import (clear_label_filters, toggle_label_filter,
-                                   toggle_label_filter_section)
+from helpers.label_helpers import (toggle_label_filter, toggle_label_filter_section)
 from helpers.todo_helpers import (add_todo, cancel_edit, edit_todo, find_todo,
                                   find_todos, wait_for_todo,
                                   wait_for_todo_to_disappear)
@@ -9,9 +8,6 @@ from helpers.todo_helpers import (add_todo, cancel_edit, edit_todo, find_todo,
 
 @pytest.mark.parametrize('test_name', ['Todo: Don\'t Filter During Edit'])
 def test_dont_filter_edit(page, todo_prefix):
-    # Remove default filter
-    clear_label_filters(page)
-
     # Add todos
     todo1_description = f'{todo_prefix} todo to edit'
     add_todo(page, todo1_description)

--- a/tests/label_filtering_test.py
+++ b/tests/label_filtering_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from helpers.label_helpers import (add_todo_w_labels, clear_label_filters,
-                                   get_label_filter_status, toggle_label_filter,
+from helpers.label_helpers import (add_todo_w_labels, get_label_filter_status, toggle_label_filter,
                                    toggle_label_filter_section)
 from helpers.todo_helpers import (list_todo_descriptions, wait_for_todo,
                                   wait_for_todo_to_disappear)
@@ -9,9 +8,6 @@ from helpers.todo_helpers import (list_todo_descriptions, wait_for_todo,
 
 @pytest.mark.parametrize('test_name', ['Label: Label Filtering'])
 def test_label_filtering(page, todo_prefix):
-    # Remove default filter
-    clear_label_filters(page)
-
     # Add todos w/ labels
     todo_5min_low_desc = f'{todo_prefix} test todo - 5min low energy'
     add_todo_w_labels(page, todo_5min_low_desc, ['low-energy', '5 minutes'])

--- a/tests/label_persistence_test.py
+++ b/tests/label_persistence_test.py
@@ -5,13 +5,13 @@ from helpers.label_helpers import (add_todo_w_labels, clear_label_filters)
 
 @pytest.mark.parametrize('test_name', ['Label: Label Persistence'])
 def test_label_persistence(page, todo_prefix):
-    # Remove default filter
-    clear_label_filters(page)
-
     # Add todo w/ 5 min & errand labels
     todo_description = f'{todo_prefix} test todo'
     labels = ['errand', '5 minutes']
     todo_item = add_todo_w_labels(page, todo_description, labels)
+
+    # Remove default filter
+    clear_label_filters(page)
 
     # Verify labels are selected
     todo_labels = todo_item.locator('[data-testid="todo-labels"] > div').all_text_contents()

--- a/ui/js/src/redux/workspaceSlice.ts
+++ b/ui/js/src/redux/workspaceSlice.ts
@@ -51,6 +51,7 @@ export const workContexts: { [key: string]: WorkContext } = {
     displayName: 'Chalk Planning',
     labels: {
       Chalk: FILTER_STATUS.Active,
+      backlog: FILTER_STATUS.Inverted,
       vague: FILTER_STATUS.Active,
     },
   },

--- a/ui/js/src/selectors.test.ts
+++ b/ui/js/src/selectors.test.ts
@@ -265,6 +265,7 @@ describe('selectActiveWorkContext', function () {
       workspace: {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
+          backlog: FILTER_STATUS.Inverted,
           vague: FILTER_STATUS.Active,
         },
       },
@@ -279,6 +280,7 @@ describe('selectActiveWorkContext', function () {
       workspace: {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
+          backlog: FILTER_STATUS.Inverted,
           vague: FILTER_STATUS.Active,
           Home: FILTER_STATUS.Active,
         },
@@ -294,6 +296,7 @@ describe('selectActiveWorkContext', function () {
       workspace: {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
+          backlog: FILTER_STATUS.Inverted,
         },
       },
     };


### PR DESCRIPTION
Also remove clearing label calls for removing Unlabeled since it happens automatically now