### PR TITLE
Validate and Deduplicate `environment` per Session

### DIFF
--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -244,7 +244,7 @@ def _sort_and_collect_timestamps(
 
 
 def _validate_and_extract_environment(
-    sessions: Dict[str, Dict[str, Any]]
+    sessions: Dict[str, Dict[str, Any]],
 ) -> Dict[str, Dict[str, Any]]:
     """
     Validate and deduplicate environment values per session.
@@ -364,10 +364,12 @@ def main():
     # Demonstrate environment validation
     validated_sessions = _validate_and_extract_environment(sorted_sessions)
     print(f"Number of validated sessions: {len(validated_sessions)}")
-    
+
     # Show environment values for each session
     for session_guid, session_data in validated_sessions.items():
-        print(f"Session '{session_guid}': environment = '{session_data['environment']}'")
+        print(
+            f"Session '{session_guid}': environment = '{session_data['environment']}'"
+        )
 
 
 if __name__ == "__main__":

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -110,7 +110,7 @@ Builds a data structure that groups successfully validated files in memory by `s
 
 You are continuing to build a script that processes session data files. At this point, you have a list of validated session records.
 
-### 🛠️ Task
+#### 🛠️ Task
 
 Implement a function that takes a list of validated session records and groups them by `session_guid`.
 
@@ -137,7 +137,7 @@ def group_by_session_guid(records: List[Dict[str, Any]]) -> Dict[str, List[Dict[
   * Values are **lists of records** (each with the full original structure) for that session.
 * Maintain insertion order (or sort later based on filename in a future step).
 
-### 🧪 Verification
+#### 🧪 Verification
 
 Add test code that:
 
@@ -164,7 +164,7 @@ Sorts each session’s grouped files by timestamp (from the filename) and prepar
 
 You are working on a script that processes grouped session data. At this point, you have a dictionary mapping `session_guid` to a list of validated file records.
 
-### 🛠️ Task
+#### 🛠️ Task
 
 Implement a function to process each session group as follows:
 
@@ -188,7 +188,7 @@ Use this function signature:
 def sort_and_collect_timestamps(grouped_sessions: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Dict[str, Any]]:
 ```
 
-### 🧪 Verification
+#### 🧪 Verification
 
 Write a test that:
 
@@ -215,6 +215,56 @@ Checks that all entries in a session have the same `environment` value, warns if
 * Confirm only one `environment` value is retained in metadata.
 
 ---
+
+**Detailed Prompt**
+
+You’re continuing to build a script that processes grouped session data. At this stage, you’ve already sorted each session’s entries and collected their `timestamp_list`.
+
+#### 🛠️ Task
+
+Implement a function that:
+
+1. Takes the output from the previous step — a dictionary mapping `session_guid` to:
+
+   * A list of `sorted_entries` (each entry includes `environment`)
+   * A `timestamp_list`
+
+2. Verifies that all `environment` values in a session are the same.
+
+   * If multiple distinct `environment` values are found:
+
+     * Log a warning including the `session_guid` and the conflicting values.
+     * Use the **first** environment value as the canonical one.
+
+3. Returns a new dictionary in this format:
+
+```python
+{
+  "abc-123": {
+    "sorted_entries": [ ... ],       # from earlier step
+    "timestamp_list": [...],         # from earlier step
+    "environment": "production"      # deduplicated and validated
+  },
+  ...
+}
+```
+
+Use this function signature:
+
+```python
+def validate_and_extract_environment(sessions: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+```
+
+#### 🧪 Verification
+
+Create test cases that:
+
+* Use session entries with consistent `environment` values.
+* Use session entries with multiple conflicting `environment` values.
+* Confirm the first environment is used and that a warning is logged for mismatches.
+* Ensure `timestamp_list` and `sorted_entries` are preserved unmodified.
+
+Do **not** merge `session_data` or write output files yet — this step focuses only on `environment` validation.
 
 ### **Step 6: Merge `session_data` Arrays**
 

--- a/session_stitching/tests/test_process_rrweb_sessions.py
+++ b/session_stitching/tests/test_process_rrweb_sessions.py
@@ -19,6 +19,7 @@ from process_rrweb_sessions import (
     _parse_and_validate_session_file,
     _group_by_session_guid,
     _sort_and_collect_timestamps,
+    _validate_and_extract_environment,
 )
 
 
@@ -106,6 +107,12 @@ def fixture_sample_validated_records(sample_json_files, sample_file_contents):
 def fixture_sample_grouped_sessions(sample_validated_records):
     """Sample grouped sessions for testing."""
     return _group_by_session_guid(sample_validated_records)
+
+
+@pytest.fixture(name="sample_sorted_sessions")
+def fixture_sample_sorted_sessions(sample_grouped_sessions):
+    """Sample sorted sessions for testing."""
+    return _sort_and_collect_timestamps(sample_grouped_sessions)
 
 
 class TestInitializeGcsClient:
@@ -675,3 +682,257 @@ class TestSortAndCollectTimestamps:
             assert timestamp_list[i] == expected_timestamp
             assert sorted_entries[i]["filename"] == expected_timestamp
             assert sorted_entries[i]["session_data"] == [{"type": i}]
+
+
+class TestValidateAndExtractEnvironment:
+    """Tests for _validate_and_extract_environment function."""
+
+    def test_validate_consistent_environment(self, sample_sorted_sessions):
+        """Test validation with consistent environment values."""
+        result = _validate_and_extract_environment(sample_sorted_sessions)
+
+        assert len(result) == 2
+        assert "abc-123" in result
+        assert "def-456" in result
+
+        # Check abc-123 session
+        abc_session = result["abc-123"]
+        assert "sorted_entries" in abc_session
+        assert "timestamp_list" in abc_session
+        assert "environment" in abc_session
+        assert abc_session["environment"] == "production"
+
+        # Check def-456 session
+        def_session = result["def-456"]
+        assert def_session["environment"] == "staging"
+
+        # Verify sorted_entries and timestamp_list are preserved
+        assert abc_session["sorted_entries"] == sample_sorted_sessions["abc-123"]["sorted_entries"]
+        assert abc_session["timestamp_list"] == sample_sorted_sessions["abc-123"]["timestamp_list"]
+
+    def test_validate_conflicting_environments(self, caplog):
+        """Test validation with conflicting environment values logs warning."""
+        # Create session with conflicting environments
+        sessions = {
+            "conflict-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_guid": "conflict-session",
+                        "session_data": [{"type": 1}],
+                        "environment": "production",
+                    },
+                    {
+                        "filename": "2025-05-02T12:11:00.000000+0000",
+                        "session_guid": "conflict-session",
+                        "session_data": [{"type": 2}],
+                        "environment": "staging",
+                    },
+                    {
+                        "filename": "2025-05-02T12:12:00.000000+0000",
+                        "session_guid": "conflict-session",
+                        "session_data": [{"type": 3}],
+                        "environment": "development",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:10:00.000000+0000",
+                    "2025-05-02T12:11:00.000000+0000",
+                    "2025-05-02T12:12:00.000000+0000",
+                ],
+            }
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        # Should use first environment value
+        assert result["conflict-session"]["environment"] == "production"
+
+        # Should log warning about conflicting values
+        assert "Session 'conflict-session' has conflicting environment values" in caplog.text
+        assert "Using first value: 'production'" in caplog.text
+
+        # Verify sorted_entries and timestamp_list are preserved
+        assert result["conflict-session"]["sorted_entries"] == sessions["conflict-session"]["sorted_entries"]
+        assert result["conflict-session"]["timestamp_list"] == sessions["conflict-session"]["timestamp_list"]
+
+    def test_validate_empty_sessions_dict(self):
+        """Test validation with empty sessions dictionary."""
+        sessions = {}
+
+        result = _validate_and_extract_environment(sessions)
+
+        assert len(result) == 0
+        assert result == {}
+
+    def test_validate_single_entry_session(self):
+        """Test validation with session containing single entry."""
+        sessions = {
+            "single-entry": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_guid": "single-entry",
+                        "session_data": [{"type": 1}],
+                        "environment": "production",
+                    }
+                ],
+                "timestamp_list": ["2025-05-02T12:10:00.000000+0000"],
+            }
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        assert len(result) == 1
+        assert result["single-entry"]["environment"] == "production"
+        assert result["single-entry"]["sorted_entries"] == sessions["single-entry"]["sorted_entries"]
+        assert result["single-entry"]["timestamp_list"] == sessions["single-entry"]["timestamp_list"]
+
+    def test_validate_preserves_all_data_structures(self):
+        """Test that validation preserves complex data structures in entries."""
+        complex_session_data = [
+            {"type": 1, "data": {"href": "https://example.com"}},
+            {"type": 2, "data": {"node": {"id": 1, "tagName": "div"}}},
+        ]
+
+        sessions = {
+            "complex-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_guid": "complex-session",
+                        "session_data": complex_session_data,
+                        "environment": "production",
+                    }
+                ],
+                "timestamp_list": ["2025-05-02T12:10:00.000000+0000"],
+            }
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        # Verify complex data is preserved exactly
+        preserved_entry = result["complex-session"]["sorted_entries"][0]
+        assert preserved_entry["session_data"] == complex_session_data
+        assert preserved_entry["filename"] == "2025-05-02T12:10:00.000000+0000"
+        assert preserved_entry["session_guid"] == "complex-session"
+
+    def test_validate_unicode_environment_values(self, caplog):
+        """Test validation with unicode environment values."""
+        sessions = {
+            "unicode-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_guid": "unicode-session",
+                        "session_data": [{"type": 1}],
+                        "environment": "测试环境",
+                    },
+                    {
+                        "filename": "2025-05-02T12:11:00.000000+0000",
+                        "session_guid": "unicode-session",
+                        "session_data": [{"type": 2}],
+                        "environment": "开发环境",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:10:00.000000+0000",
+                    "2025-05-02T12:11:00.000000+0000",
+                ],
+            }
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        # Should use first unicode environment value
+        assert result["unicode-session"]["environment"] == "测试环境"
+
+        # Should log warning about conflicting unicode values
+        assert "Session 'unicode-session' has conflicting environment values" in caplog.text
+
+    def test_validate_multiple_sessions_mixed_consistency(self, caplog):
+        """Test validation with multiple sessions, some consistent, some conflicting."""
+        sessions = {
+            "consistent-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_guid": "consistent-session",
+                        "session_data": [{"type": 1}],
+                        "environment": "production",
+                    },
+                    {
+                        "filename": "2025-05-02T12:11:00.000000+0000",
+                        "session_guid": "consistent-session",
+                        "session_data": [{"type": 2}],
+                        "environment": "production",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:10:00.000000+0000",
+                    "2025-05-02T12:11:00.000000+0000",
+                ],
+            },
+            "conflicting-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:20:00.000000+0000",
+                        "session_guid": "conflicting-session",
+                        "session_data": [{"type": 1}],
+                        "environment": "staging",
+                    },
+                    {
+                        "filename": "2025-05-02T12:21:00.000000+0000",
+                        "session_guid": "conflicting-session",
+                        "session_data": [{"type": 2}],
+                        "environment": "development",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:20:00.000000+0000",
+                    "2025-05-02T12:21:00.000000+0000",
+                ],
+            },
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        # Consistent session should not trigger warning
+        assert result["consistent-session"]["environment"] == "production"
+
+        # Conflicting session should use first value and trigger warning
+        assert result["conflicting-session"]["environment"] == "staging"
+        assert "Session 'conflicting-session' has conflicting environment values" in caplog.text
+        assert "Session 'consistent-session'" not in caplog.text
+
+    def test_validate_large_number_of_conflicting_environments(self, caplog):
+        """Test validation with many different environment values in one session."""
+        num_entries = 10
+        entries = []
+        timestamps = []
+
+        for i in range(num_entries):
+            timestamp = f"2025-05-02T12:{i:02d}:00.000000+0000"
+            entries.append({
+                "filename": timestamp,
+                "session_guid": "many-envs",
+                "session_data": [{"type": i}],
+                "environment": f"env-{i}",
+            })
+            timestamps.append(timestamp)
+
+        sessions = {
+            "many-envs": {
+                "sorted_entries": entries,
+                "timestamp_list": timestamps,
+            }
+        }
+
+        result = _validate_and_extract_environment(sessions)
+
+        # Should use first environment value
+        assert result["many-envs"]["environment"] == "env-0"
+
+        # Should log warning about all conflicting values
+        assert "Session 'many-envs' has conflicting environment values" in caplog.text
+        assert "Using first value: 'env-0'" in caplog.text

--- a/session_stitching/tests/test_process_rrweb_sessions.py
+++ b/session_stitching/tests/test_process_rrweb_sessions.py
@@ -707,54 +707,43 @@ class TestValidateAndExtractEnvironment:
         assert def_session["environment"] == "staging"
 
         # Verify sorted_entries and timestamp_list are preserved
-        assert abc_session["sorted_entries"] == sample_sorted_sessions["abc-123"]["sorted_entries"]
-        assert abc_session["timestamp_list"] == sample_sorted_sessions["abc-123"]["timestamp_list"]
+        assert (
+            abc_session["sorted_entries"]
+            == sample_sorted_sessions["abc-123"]["sorted_entries"]
+        )
+        assert (
+            abc_session["timestamp_list"]
+            == sample_sorted_sessions["abc-123"]["timestamp_list"]
+        )
 
-    def test_validate_conflicting_environments(self, caplog):
+    def test_validate_conflicting_environments(self, caplog, sample_sorted_sessions):
         """Test validation with conflicting environment values logs warning."""
         # Create session with conflicting environments
-        sessions = {
-            "conflict-session": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:10:00.000000+0000",
-                        "session_guid": "conflict-session",
-                        "session_data": [{"type": 1}],
-                        "environment": "production",
-                    },
-                    {
-                        "filename": "2025-05-02T12:11:00.000000+0000",
-                        "session_guid": "conflict-session",
-                        "session_data": [{"type": 2}],
-                        "environment": "staging",
-                    },
-                    {
-                        "filename": "2025-05-02T12:12:00.000000+0000",
-                        "session_guid": "conflict-session",
-                        "session_data": [{"type": 3}],
-                        "environment": "development",
-                    },
-                ],
-                "timestamp_list": [
-                    "2025-05-02T12:10:00.000000+0000",
-                    "2025-05-02T12:11:00.000000+0000",
-                    "2025-05-02T12:12:00.000000+0000",
-                ],
-            }
-        }
+        sample_sorted_sessions["abc-123"]["sorted_entries"][0][
+            "environment"
+        ] = "development"
 
-        result = _validate_and_extract_environment(sessions)
+        result = _validate_and_extract_environment(sample_sorted_sessions)
 
         # Should use first environment value
-        assert result["conflict-session"]["environment"] == "production"
+        assert result["abc-123"]["environment"] == "development"
 
         # Should log warning about conflicting values
-        assert "Session 'conflict-session' has conflicting environment values" in caplog.text
-        assert "Using first value: 'production'" in caplog.text
+        assert "Session 'abc-123' has conflicting environment values" in caplog.text
+        assert "Using first value: 'development'" in caplog.text
 
         # Verify sorted_entries and timestamp_list are preserved
-        assert result["conflict-session"]["sorted_entries"] == sessions["conflict-session"]["sorted_entries"]
-        assert result["conflict-session"]["timestamp_list"] == sessions["conflict-session"]["timestamp_list"]
+        assert (
+            result["abc-123"]["sorted_entries"]
+            == sample_sorted_sessions["abc-123"]["sorted_entries"]
+        )
+        assert (
+            result["abc-123"]["timestamp_list"]
+            == sample_sorted_sessions["abc-123"]["timestamp_list"]
+        )
+
+        # Other sessions should not be impacted
+        assert result["def-456"]["environment"] == "staging"
 
     def test_validate_empty_sessions_dict(self):
         """Test validation with empty sessions dictionary."""
@@ -765,146 +754,6 @@ class TestValidateAndExtractEnvironment:
         assert len(result) == 0
         assert result == {}
 
-    def test_validate_single_entry_session(self):
-        """Test validation with session containing single entry."""
-        sessions = {
-            "single-entry": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:10:00.000000+0000",
-                        "session_guid": "single-entry",
-                        "session_data": [{"type": 1}],
-                        "environment": "production",
-                    }
-                ],
-                "timestamp_list": ["2025-05-02T12:10:00.000000+0000"],
-            }
-        }
-
-        result = _validate_and_extract_environment(sessions)
-
-        assert len(result) == 1
-        assert result["single-entry"]["environment"] == "production"
-        assert result["single-entry"]["sorted_entries"] == sessions["single-entry"]["sorted_entries"]
-        assert result["single-entry"]["timestamp_list"] == sessions["single-entry"]["timestamp_list"]
-
-    def test_validate_preserves_all_data_structures(self):
-        """Test that validation preserves complex data structures in entries."""
-        complex_session_data = [
-            {"type": 1, "data": {"href": "https://example.com"}},
-            {"type": 2, "data": {"node": {"id": 1, "tagName": "div"}}},
-        ]
-
-        sessions = {
-            "complex-session": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:10:00.000000+0000",
-                        "session_guid": "complex-session",
-                        "session_data": complex_session_data,
-                        "environment": "production",
-                    }
-                ],
-                "timestamp_list": ["2025-05-02T12:10:00.000000+0000"],
-            }
-        }
-
-        result = _validate_and_extract_environment(sessions)
-
-        # Verify complex data is preserved exactly
-        preserved_entry = result["complex-session"]["sorted_entries"][0]
-        assert preserved_entry["session_data"] == complex_session_data
-        assert preserved_entry["filename"] == "2025-05-02T12:10:00.000000+0000"
-        assert preserved_entry["session_guid"] == "complex-session"
-
-    def test_validate_unicode_environment_values(self, caplog):
-        """Test validation with unicode environment values."""
-        sessions = {
-            "unicode-session": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:10:00.000000+0000",
-                        "session_guid": "unicode-session",
-                        "session_data": [{"type": 1}],
-                        "environment": "测试环境",
-                    },
-                    {
-                        "filename": "2025-05-02T12:11:00.000000+0000",
-                        "session_guid": "unicode-session",
-                        "session_data": [{"type": 2}],
-                        "environment": "开发环境",
-                    },
-                ],
-                "timestamp_list": [
-                    "2025-05-02T12:10:00.000000+0000",
-                    "2025-05-02T12:11:00.000000+0000",
-                ],
-            }
-        }
-
-        result = _validate_and_extract_environment(sessions)
-
-        # Should use first unicode environment value
-        assert result["unicode-session"]["environment"] == "测试环境"
-
-        # Should log warning about conflicting unicode values
-        assert "Session 'unicode-session' has conflicting environment values" in caplog.text
-
-    def test_validate_multiple_sessions_mixed_consistency(self, caplog):
-        """Test validation with multiple sessions, some consistent, some conflicting."""
-        sessions = {
-            "consistent-session": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:10:00.000000+0000",
-                        "session_guid": "consistent-session",
-                        "session_data": [{"type": 1}],
-                        "environment": "production",
-                    },
-                    {
-                        "filename": "2025-05-02T12:11:00.000000+0000",
-                        "session_guid": "consistent-session",
-                        "session_data": [{"type": 2}],
-                        "environment": "production",
-                    },
-                ],
-                "timestamp_list": [
-                    "2025-05-02T12:10:00.000000+0000",
-                    "2025-05-02T12:11:00.000000+0000",
-                ],
-            },
-            "conflicting-session": {
-                "sorted_entries": [
-                    {
-                        "filename": "2025-05-02T12:20:00.000000+0000",
-                        "session_guid": "conflicting-session",
-                        "session_data": [{"type": 1}],
-                        "environment": "staging",
-                    },
-                    {
-                        "filename": "2025-05-02T12:21:00.000000+0000",
-                        "session_guid": "conflicting-session",
-                        "session_data": [{"type": 2}],
-                        "environment": "development",
-                    },
-                ],
-                "timestamp_list": [
-                    "2025-05-02T12:20:00.000000+0000",
-                    "2025-05-02T12:21:00.000000+0000",
-                ],
-            },
-        }
-
-        result = _validate_and_extract_environment(sessions)
-
-        # Consistent session should not trigger warning
-        assert result["consistent-session"]["environment"] == "production"
-
-        # Conflicting session should use first value and trigger warning
-        assert result["conflicting-session"]["environment"] == "staging"
-        assert "Session 'conflicting-session' has conflicting environment values" in caplog.text
-        assert "Session 'consistent-session'" not in caplog.text
-
     def test_validate_large_number_of_conflicting_environments(self, caplog):
         """Test validation with many different environment values in one session."""
         num_entries = 10
@@ -913,12 +762,14 @@ class TestValidateAndExtractEnvironment:
 
         for i in range(num_entries):
             timestamp = f"2025-05-02T12:{i:02d}:00.000000+0000"
-            entries.append({
-                "filename": timestamp,
-                "session_guid": "many-envs",
-                "session_data": [{"type": i}],
-                "environment": f"env-{i}",
-            })
+            entries.append(
+                {
+                    "filename": timestamp,
+                    "session_guid": "many-envs",
+                    "session_data": [{"type": i}],
+                    "environment": f"env-{i}",
+                }
+            )
             timestamps.append(timestamp)
 
         sessions = {

--- a/session_stitching/todo.md
+++ b/session_stitching/todo.md
@@ -54,14 +54,14 @@
 ## Step 5: Validate and Deduplicate `environment` per Session
 
 ### Tasks:
-- [ ] Check that all entries in a session have same `environment` value
-- [ ] Log warning when environment values differ within a session
-- [ ] Use first encountered `environment` value when conflicts exist
-- [ ] Store single `environment` value in session metadata
-- [ ] Create test data with consistent environments
-- [ ] Create test data with inconsistent environments
-- [ ] Verify warning is logged for inconsistent values
-- [ ] Confirm only one `environment` value is retained
+- [x] Check that all entries in a session have same `environment` value
+- [x] Log warning when environment values differ within a session
+- [x] Use first encountered `environment` value when conflicts exist
+- [x] Store single `environment` value in session metadata
+- [x] Create test data with consistent environments
+- [x] Create test data with inconsistent environments
+- [x] Verify warning is logged for inconsistent values
+- [x] Confirm only one `environment` value is retained
 
 ## Step 6: Merge `session_data` Arrays
 


### PR DESCRIPTION
**What it accomplishes:**
Checks that all entries in a session have the same `environment` value, warns if not, and uses the first encountered.

**How to verify:**

* Use test data with both consistent and inconsistent environments.
* Verify warning is logged when values differ.
* Confirm only one `environment` value is retained in metadata.

--
Adds a new step to validate and deduplicate the environment field across session entries, ensuring consistency and logging any conflicts.

- Implements _validate_and_extract_environment in process_rrweb_sessions.py
- Adds tests for consistent, conflicting, and empty sessions in tests/test_process_rrweb_sessions.py
- Updates documentation in prompt_plan.md and marks task completion in todo.md