### PR TITLE
Merge `session_data` Arrays

### DIFF
--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -323,7 +323,9 @@ def _download_json_files(bucket_name: str) -> List[Tuple[str, str]]:
     return file_contents
 
 
-def merge_session_data(sessions: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def _merge_session_data(
+    sessions: Dict[str, Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
     """
     Merge session_data arrays from sorted session entries into final output format.
 
@@ -417,7 +419,7 @@ def process_rrweb_sessions(bucket_name: str) -> Dict[str, Dict[str, Any]]:
     logger.info("Number of validated sessions: %d", len(validated_sessions))
 
     # Merge session data arrays
-    final_sessions = merge_session_data(validated_sessions)
+    final_sessions = _merge_session_data(validated_sessions)
     logger.info("Number of final sessions: %d", len(final_sessions))
 
     return final_sessions

--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -323,17 +323,66 @@ def _download_json_files(bucket_name: str) -> List[Tuple[str, str]]:
     return file_contents
 
 
-def process_rrweb_sessions(bucket_name: str) -> List[Dict[str, Any]]:
+def merge_session_data(sessions: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """
+    Merge session_data arrays from sorted session entries into final output format.
+
+    Args:
+        sessions: Dictionary mapping session_guid to session data containing:
+                 - sorted_entries: list of validated and chronologically ordered records
+                 - timestamp_list: list of timestamps for the session
+                 - environment: canonical environment string for the session
+
+    Returns:
+        Dict[str, Dict[str, Any]]: Dictionary with session_guid as keys and values containing:
+                                   - session_guid: the session identifier
+                                   - rrweb_data: merged list of rrweb events
+                                   - metadata: dict with environment and timestamp_list
+    """
+    merged_sessions = {}
+
+    for session_guid, session_data in sessions.items():
+        sorted_entries = session_data["sorted_entries"]
+        timestamp_list = session_data["timestamp_list"]
+        environment = session_data["environment"]
+
+        # Merge all session_data arrays in chronological order
+        rrweb_data = []
+        for entry in sorted_entries:
+            rrweb_data.extend(entry["session_data"])
+
+        # Create final session structure
+        merged_sessions[session_guid] = {
+            "session_guid": session_guid,
+            "rrweb_data": rrweb_data,
+            "metadata": {
+                "environment": environment,
+                "timestamp_list": timestamp_list,
+            },
+        }
+
+        logger.info(
+            "Session '%s': merged %d events from %d files",
+            session_guid,
+            len(rrweb_data),
+            len(sorted_entries),
+        )
+
+    logger.info("Merged session data for %d sessions", len(merged_sessions))
+    return merged_sessions
+
+
+def process_rrweb_sessions(bucket_name: str) -> Dict[str, Dict[str, Any]]:
     """
     Main function for processing rrweb session data.
     This function orchestrates the downloading, parsing, grouping, sorting,
-    and validating of session files from a GCS bucket.
+    validating, and merging of session files from a GCS bucket.
 
     Args:
         bucket_name: Name of the GCS bucket containing rrweb session JSON files
 
     Returns:
-        List[Dict[str, Any]]: List of validated session data dictionaries
+        Dict[str, Dict[str, Any]]: Dictionary mapping session_guid to final session objects
     """
     # Download all JSON files
     files = _download_json_files(bucket_name)
@@ -367,7 +416,11 @@ def process_rrweb_sessions(bucket_name: str) -> List[Dict[str, Any]]:
     validated_sessions = _validate_and_extract_environment(sorted_sessions)
     logger.info("Number of validated sessions: %d", len(validated_sessions))
 
-    return validated_sessions
+    # Merge session data arrays
+    final_sessions = merge_session_data(validated_sessions)
+    logger.info("Number of final sessions: %d", len(final_sessions))
+
+    return final_sessions
 
 
 if __name__ == "__main__":

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -277,6 +277,55 @@ For each session, merges all ordered `session_data` arrays into a single rrweb e
 * Confirm that merged `rrweb_data` matches total event count.
 * Add assertions in unit tests for combined arrays.
 
+**Detailed Prompt**
+
+You are now ready to merge the actual rrweb event data from sorted session entries.
+
+### 🛠️ Task
+
+Implement a function that:
+
+1. Takes as input a dictionary where each key is a `session_guid` and the value is a dictionary containing:
+
+   * `sorted_entries`: list of validated and chronologically ordered records, each with a `session_data` list
+   * `timestamp_list`: list of timestamps for the session
+   * `environment`: canonical environment string for the session
+
+2. Merges all `session_data` arrays (in order) into a single list per session.
+
+3. Returns a new dictionary in this format:
+
+```python
+{
+  "abc-123": {
+    "session_guid": "abc-123",
+    "rrweb_data": [...],          # merged list of rrweb events
+    "metadata": {
+      "environment": "production",
+      "timestamp_list": [...]
+    }
+  },
+  ...
+}
+```
+
+Use this function signature:
+
+```python
+def merge_session_data(sessions: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+```
+
+### 🧪 Verification
+
+Add tests that:
+
+* Confirm merged `rrweb_data` preserves the order of events from the sorted entries.
+* Validate that the `metadata` block is correctly constructed and unmodified.
+* Handle edge cases like empty `session_data` lists gracefully.
+* Confirm that the total event count equals the sum of all `session_data` lengths for the session.
+
+Do not write any files to disk in this step — this step only prepares the final structured output per session.
+
 ---
 
 ### **Step 7: Save Final Session Objects to Compact JSON**

--- a/session_stitching/tests/test_process_rrweb_sessions.py
+++ b/session_stitching/tests/test_process_rrweb_sessions.py
@@ -18,6 +18,7 @@ from process_rrweb_sessions import (
     _group_by_session_guid,
     _sort_and_collect_timestamps,
     _validate_and_extract_environment,
+    merge_session_data,
     process_rrweb_sessions,
 )
 
@@ -164,15 +165,19 @@ class TestSessionProcessingPipeline:
 
         # Check SESSION_1 properties
         session_1 = final_sessions[SESSION_1_KEY]
-        assert session_1["environment"] == "production"
-        assert len(session_1["timestamp_list"]) == 2
-        assert len(session_1["sorted_entries"]) == 2
+        assert session_1["session_guid"] == SESSION_1_KEY
+        assert "rrweb_data" in session_1
+        assert "metadata" in session_1
+        assert session_1["metadata"]["environment"] == "production"
+        assert len(session_1["metadata"]["timestamp_list"]) == 2
 
         # Check SESSION_2 properties
         session_2 = final_sessions[SESSION_2_KEY]
-        assert session_2["environment"] == "staging"
-        assert len(session_2["timestamp_list"]) == 1
-        assert len(session_2["sorted_entries"]) == 1
+        assert session_2["session_guid"] == SESSION_2_KEY
+        assert "rrweb_data" in session_2
+        assert "metadata" in session_2
+        assert session_2["metadata"]["environment"] == "staging"
+        assert len(session_2["metadata"]["timestamp_list"]) == 1
 
     def test_process_rrweb_sessions_orders_cronologically(self, sample_rrweb_data):
         """Test that session data is correctly merged and ordered."""
@@ -180,44 +185,44 @@ class TestSessionProcessingPipeline:
 
         # Verify timestamp ordering (chronological)
         session_1 = final_sessions[SESSION_1_KEY]
-        timestamps = session_1["timestamp_list"]
+        timestamps = session_1["metadata"]["timestamp_list"]
         assert timestamps == sorted(timestamps)
         assert timestamps[0] == "2025-05-02T12:10:50.644423+0000"
         assert timestamps[1] == "2025-05-02T12:11:30.991832+0000"
 
-        # Check SESSION_1 data ordering
-        session_entries = session_1["sorted_entries"]
-
-        # First entry should be from earlier timestamp
-        first_entry = session_entries[0]
-        assert first_entry["filename"] == "2025-05-02T12:10:50.644423+0000"
-        assert first_entry["session_data"] == sample_rrweb_data["session_1_file_2"]
-
-        # Second entry should be from later timestamp
-        second_entry = session_entries[1]
-        assert second_entry["filename"] == "2025-05-02T12:11:30.991832+0000"
-        assert second_entry["session_data"] == sample_rrweb_data["session_1_file_1"]
+        # Check merged rrweb_data ordering
+        rrweb_data = session_1["rrweb_data"]
+        
+        # Should contain events from both files in chronological order
+        # First file (earlier timestamp) events should come first
+        expected_first_events = sample_rrweb_data["session_1_file_2"]
+        expected_second_events = sample_rrweb_data["session_1_file_1"]
+        
+        # Verify the merged data contains all events in correct order
+        assert rrweb_data[:len(expected_first_events)] == expected_first_events
+        assert rrweb_data[len(expected_first_events):] == expected_second_events
+        assert len(rrweb_data) == len(expected_first_events) + len(expected_second_events)
 
     def test_handles_malformed_files_gracefully(self, caplog):
         """Test pipeline skips invalid files and continues processing."""
         final_sessions = process_rrweb_sessions("mock_bucket_name")
 
-        all_files = [
-            entry["filename"]
+        all_timestamps = [
+            timestamp
             for session in final_sessions.values()
-            for entry in session["sorted_entries"]
+            for timestamp in session["metadata"]["timestamp_list"]
         ]
 
         # Verify that malformed JSON file and missing fields file are omitted
         assert (
-            "2025-05-02T12:13:00.000000+0000" not in all_files
+            "2025-05-02T12:13:00.000000+0000" not in all_timestamps
         )  # Malformed JSON file should be skipped
         assert (
-            "2025-05-02T12:14:00.000000+0000" not in all_files
+            "2025-05-02T12:14:00.000000+0000" not in all_timestamps
         )  # Missing fields file should be skipped
 
         # Should still process valid files
-        assert len(all_files) == 3
+        assert len(all_timestamps) == 3
 
         # Verify warnings were logged
         assert "Failed to parse JSON in file" in caplog.text
@@ -249,7 +254,7 @@ class TestSessionProcessingPipeline:
         final_sessions = process_rrweb_sessions("mock_bucket_name")
 
         # Should use first environment value
-        assert final_sessions["conflict-session"]["environment"] == "production"
+        assert final_sessions["conflict-session"]["metadata"]["environment"] == "production"
 
         # Should log warning
         assert "conflicting environment values" in caplog.text
@@ -436,6 +441,186 @@ class TestTimestampOrdering:
             result["single-file"]["timestamp_list"][0]
             == "2025-05-02T12:10:00.000000+0000"
         )
+
+
+class TestMergeSessionData:
+    """Test session data merging functionality."""
+
+    def test_merge_session_data_preserves_event_order(self):
+        """Test that merged rrweb_data preserves order of events from sorted entries."""
+        sessions = {
+            "test-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_data": [{"type": 1, "order": 1}, {"type": 2, "order": 2}],
+                        "environment": "production",
+                    },
+                    {
+                        "filename": "2025-05-02T12:11:00.000000+0000",
+                        "session_data": [{"type": 3, "order": 3}, {"type": 4, "order": 4}],
+                        "environment": "production",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:10:00.000000+0000",
+                    "2025-05-02T12:11:00.000000+0000",
+                ],
+                "environment": "production",
+            }
+        }
+
+        result = merge_session_data(sessions)
+
+        # Verify structure
+        assert "test-session" in result
+        session = result["test-session"]
+        assert session["session_guid"] == "test-session"
+        assert "rrweb_data" in session
+        assert "metadata" in session
+
+        # Verify event order preservation
+        rrweb_data = session["rrweb_data"]
+        assert len(rrweb_data) == 4
+        assert rrweb_data[0]["order"] == 1
+        assert rrweb_data[1]["order"] == 2
+        assert rrweb_data[2]["order"] == 3
+        assert rrweb_data[3]["order"] == 4
+
+    def test_merge_session_data_metadata_construction(self):
+        """Test that metadata block is correctly constructed and unmodified."""
+        sessions = {
+            "metadata-test": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_data": [{"type": 1}],
+                        "environment": "staging",
+                    }
+                ],
+                "timestamp_list": ["2025-05-02T12:10:00.000000+0000"],
+                "environment": "staging",
+            }
+        }
+
+        result = merge_session_data(sessions)
+
+        # Verify metadata structure
+        metadata = result["metadata-test"]["metadata"]
+        assert metadata["environment"] == "staging"
+        assert metadata["timestamp_list"] == ["2025-05-02T12:10:00.000000+0000"]
+
+    def test_merge_session_data_handles_empty_session_data(self):
+        """Test edge case of empty session_data lists gracefully."""
+        sessions = {
+            "empty-session": {
+                "sorted_entries": [
+                    {
+                        "filename": "2025-05-02T12:10:00.000000+0000",
+                        "session_data": [],  # Empty session data
+                        "environment": "test",
+                    },
+                    {
+                        "filename": "2025-05-02T12:11:00.000000+0000",
+                        "session_data": [{"type": 1}],  # Non-empty session data
+                        "environment": "test",
+                    },
+                ],
+                "timestamp_list": [
+                    "2025-05-02T12:10:00.000000+0000",
+                    "2025-05-02T12:11:00.000000+0000",
+                ],
+                "environment": "test",
+            }
+        }
+
+        result = merge_session_data(sessions)
+
+        # Should handle empty lists gracefully
+        rrweb_data = result["empty-session"]["rrweb_data"]
+        assert len(rrweb_data) == 1  # Only the non-empty entry
+        assert rrweb_data[0]["type"] == 1
+
+    def test_merge_session_data_event_count_verification(self):
+        """Test that total event count equals sum of all session_data lengths."""
+        sessions = {
+            "count-test": {
+                "sorted_entries": [
+                    {
+                        "filename": "file1",
+                        "session_data": [{"event": 1}, {"event": 2}, {"event": 3}],
+                        "environment": "test",
+                    },
+                    {
+                        "filename": "file2",
+                        "session_data": [{"event": 4}, {"event": 5}],
+                        "environment": "test",
+                    },
+                    {
+                        "filename": "file3",
+                        "session_data": [{"event": 6}],
+                        "environment": "test",
+                    },
+                ],
+                "timestamp_list": ["file1", "file2", "file3"],
+                "environment": "test",
+            }
+        }
+
+        result = merge_session_data(sessions)
+
+        # Calculate expected total
+        expected_total = sum(
+            len(entry["session_data"]) for entry in sessions["count-test"]["sorted_entries"]
+        )
+        actual_total = len(result["count-test"]["rrweb_data"])
+
+        assert actual_total == expected_total == 6
+
+    def test_merge_session_data_handles_multiple_sessions(self):
+        """Test merging multiple sessions simultaneously."""
+        sessions = {
+            "session-1": {
+                "sorted_entries": [
+                    {
+                        "filename": "s1-file1",
+                        "session_data": [{"session": 1, "event": 1}],
+                        "environment": "prod",
+                    }
+                ],
+                "timestamp_list": ["s1-file1"],
+                "environment": "prod",
+            },
+            "session-2": {
+                "sorted_entries": [
+                    {
+                        "filename": "s2-file1",
+                        "session_data": [{"session": 2, "event": 1}],
+                        "environment": "dev",
+                    }
+                ],
+                "timestamp_list": ["s2-file1"],
+                "environment": "dev",
+            },
+        }
+
+        result = merge_session_data(sessions)
+
+        # Verify both sessions processed
+        assert len(result) == 2
+        assert "session-1" in result
+        assert "session-2" in result
+
+        # Verify session isolation
+        assert result["session-1"]["rrweb_data"][0]["session"] == 1
+        assert result["session-2"]["rrweb_data"][0]["session"] == 2
+        assert result["session-1"]["metadata"]["environment"] == "prod"
+        assert result["session-2"]["metadata"]["environment"] == "dev"
+
+    def test_merge_session_data_handles_empty_input(self):
+        """Test merge handles empty sessions dictionary."""
+        result = merge_session_data({})
+        assert result == {}
 
 
 class TestPrivateMethodEdgeCases:

--- a/session_stitching/todo.md
+++ b/session_stitching/todo.md
@@ -66,13 +66,13 @@
 ## Step 6: Merge `session_data` Arrays
 
 ### Tasks:
-- [ ] For each session, concatenate all `session_data` arrays in timestamp order
-- [ ] Create single merged rrweb event stream per session
-- [ ] Preserve order of events within each file and across files
-- [ ] Store merged data as `rrweb_data` field
-- [ ] Test against sessions with known event counts
-- [ ] Verify merged `rrweb_data` matches total expected event count
-- [ ] Write unit tests with assertions for combined arrays
+- [x] For each session, concatenate all `session_data` arrays in timestamp order
+- [x] Create single merged rrweb event stream per session
+- [x] Preserve order of events within each file and across files
+- [x] Store merged data as `rrweb_data` field
+- [x] Test against sessions with known event counts
+- [x] Verify merged `rrweb_data` matches total expected event count
+- [x] Write unit tests with assertions for combined arrays
 
 ## Step 7: Save Final Session Objects to Compact JSON
 


### PR DESCRIPTION
**What it accomplishes:**
For each session, merges all ordered `session_data` arrays into a single rrweb event stream.

**How to verify:**

* Run against test sessions with known event counts.
* Confirm that merged `rrweb_data` matches total event count.
* Add assertions in unit tests for combined arrays.

--
### 🎯 Completed Tasks
- Implemented `merge_session_data()` function in `process_rrweb_sessions.py`
- Updated `process_rrweb_sessions()` to use the new merge function
- Added comprehensive test cases for the merge functionality
- Updated test cases to match new output structure
- Checked off completed tasks in `todo.md`

### 🔍 Key Implementation Details
- Merges `session_data` arrays from sorted entries while preserving chronological order
- Creates a new dictionary structure with `session_guid`, `rrweb_data`, and `metadata`
- Handles various edge cases like empty session data and multiple sessions
- Maintains event order within and across files
