### PR TITLE
Add CLI Interface (bucket name, output dir, verbosity)

### DIFF
--- a/docs/prompts/implement_step.md
+++ b/docs/prompts/implement_step.md
@@ -1,0 +1,5 @@
+Please read `<PATH_TO_SPEC>` to get an idea of the project, then read `<PATH_TO_PROMPT_PLAN>` to get an idea of the steps to complete the project.  Then read `<PATH_TO_CHECKLIST>` to get an idea of where we are in the project.  Complete the task below, as you complete todos, please check them off in `<PATH_TO_CHECKLIST>`.
+
+Next, please work on Step <STEP_NUMBER>: <STEP_DESCRIPTION> from the `<PATH_TO_PROMPT_PLAN>`.
+
+<DETAILED_PROMPT>

--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -200,7 +200,7 @@ def _group_by_session_guid(
 
     # Log number of files per session
     for session_guid, session_records in grouped_sessions.items():
-        logger.info("Session '%s': %d files", session_guid, len(session_records))
+        logger.debug("Session '%s': %d files", session_guid, len(session_records))
 
     return grouped_sessions
 
@@ -233,7 +233,7 @@ def _sort_and_collect_timestamps(
             "timestamp_list": timestamp_list,
         }
 
-        logger.info(
+        logger.debug(
             "Session '%s': sorted %d entries by timestamp",
             session_guid,
             len(sorted_entries),
@@ -367,7 +367,7 @@ def _merge_session_data(
             },
         }
 
-        logger.info(
+        logger.debug(
             "Session '%s': merged %d events from %d files",
             session_guid,
             len(rrweb_data),
@@ -436,7 +436,7 @@ def _write_sessions_to_disk(
         with open(filepath, "w", encoding="utf-8") as f:
             json.dump(session_data, f, separators=(",", ":"), ensure_ascii=False)
 
-        logger.info("Wrote session '%s' to %s", session_guid, filepath)
+        logger.debug("Wrote session '%s' to %s", session_guid, filepath)
 
     logger.info("Successfully wrote %d sessions to %s", len(sessions), output_dir)
 

--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -594,10 +594,10 @@ def main() -> None:
         logger.info("Session processing completed successfully")
 
     except KeyboardInterrupt:
-        print("\nOperation cancelled by user", file=sys.stderr)
+        logger.error("Operation cancelled by user")
         sys.exit(1)
     except Exception as e:  # pylint: disable=broad-except
-        print(f"Error: {e}", file=sys.stderr)
+        logger.error("Error: %s", e)
         sys.exit(1)
 
 

--- a/session_stitching/process_rrweb_sessions.py
+++ b/session_stitching/process_rrweb_sessions.py
@@ -442,7 +442,7 @@ def _write_sessions_to_disk(
 
 
 def process_rrweb_sessions(
-    bucket_name: str, output_dir: str = "./stitched_sessions"
+    bucket_name: str, output_dir: str = "./output_sessions"
 ) -> None:
     """
     Main function for processing rrweb session data.
@@ -536,8 +536,8 @@ Examples:
     # Optional arguments
     parser.add_argument(
         "--output_dir",
-        default="./stitched_sessions",
-        help="Local directory where session files will be saved (default: ./stitched_sessions)",
+        default="./output_sessions",
+        help="Local directory where session files will be saved (default: ./output_sessions)",
     )
 
     parser.add_argument(
@@ -583,7 +583,6 @@ def main() -> None:
         _setup_logging(args.log_level)
 
         # Log the configuration being used
-        logger = logging.getLogger(__name__)
         logger.info("Starting rrweb session processing")
         logger.info("Bucket: %s", args.bucket)
         logger.info("Output directory: %s", args.output_dir)
@@ -597,7 +596,7 @@ def main() -> None:
     except KeyboardInterrupt:
         print("\nOperation cancelled by user", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -475,6 +475,7 @@ Adds user-facing command-line arguments to set GCS bucket name, output directory
 * Add a help message and test with `--help`.
 
 **Detailed Prompt**
+
 You’ve implemented a multi-stage Python script to process rrweb session files from a GCS bucket. Now you’ll expose it via a command-line interface.
 
 ### 🛠️ Task

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -504,7 +504,7 @@ Use this CLI structure as a starting point:
 ```bash
 python process_rrweb_sessions.py \
   --bucket my-rrweb-bucket \
-  --output_dir ./stitched_sessions \
+  --output_dir ./output_sessions \
   --log_level DEBUG
 ```
 

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -474,3 +474,50 @@ Adds user-facing command-line arguments to set GCS bucket name, output directory
 * Confirm that behavior (paths, verbosity) matches input.
 * Add a help message and test with `--help`.
 
+**Detailed Prompt**
+Certainly! Here's a clean and comprehensive prompt for **Step 9: Add CLI Interface (bucket name, output dir, verbosity)**.
+
+You’ve implemented a multi-stage Python script to process rrweb session files from a GCS bucket. Now you’ll expose it via a command-line interface.
+
+### 🛠️ Task
+
+Add a CLI interface using Python’s `argparse` module that allows the user to configure the following:
+
+#### Required arguments:
+
+* `--bucket`: the name of the GCS bucket to read from
+
+#### Optional arguments:
+
+* `--output_dir`: local directory where session files will be saved (default: `"./stitched_sessions"`)
+* `--log_level`: controls verbosity of logging (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; default: `INFO`)
+
+### Requirements:
+
+1. Configure logging level using `logging.basicConfig(level=...)` based on the `--log_level` flag.
+2. Validate that `--bucket` is provided; exit with a clear error if not.
+3. Use the parsed CLI arguments to invoke your main session processing function(s).
+
+You may assume all the processing steps (from downloading to writing files) are composed in a `main()` function that accepts the bucket name and output directory.
+
+Use this CLI structure as a starting point:
+
+```bash
+python process_rrweb_sessions.py \
+  --bucket my-rrweb-bucket \
+  --output_dir ./stitched_sessions \
+  --log_level DEBUG
+```
+
+### 🧪 Verification
+
+Add a `main()` block that:
+
+* Parses CLI arguments.
+* Sets up logging.
+* Calls your pipeline entry point with the configured values.
+* Allows the script to be run standalone with `python process_rrweb_sessions.py`.
+
+Test by running the script with different flags and confirming behavior matches expectations.
+
+Do not change processing logic or add new features — this step is only about creating a clean, user-friendly CLI interface.

--- a/session_stitching/prompt_plan.md
+++ b/session_stitching/prompt_plan.md
@@ -475,8 +475,6 @@ Adds user-facing command-line arguments to set GCS bucket name, output directory
 * Add a help message and test with `--help`.
 
 **Detailed Prompt**
-Certainly! Here's a clean and comprehensive prompt for **Step 9: Add CLI Interface (bucket name, output dir, verbosity)**.
-
 You’ve implemented a multi-stage Python script to process rrweb session files from a GCS bucket. Now you’ll expose it via a command-line interface.
 
 ### 🛠️ Task

--- a/session_stitching/todo.md
+++ b/session_stitching/todo.md
@@ -103,13 +103,13 @@
 ## Step 9: Add CLI Interface (bucket name, output dir, verbosity)
 
 ### Tasks:
-- [ ] Add command-line argument parsing using `argparse`
-- [ ] Add `--bucket` argument for GCS bucket name
-- [ ] Add `--output_dir` argument for output directory path
-- [ ] Add `--verbose` or logging level arguments
-- [ ] Set up logging configuration based on verbosity level
-- [ ] Add `--help` message with usage instructions
-- [ ] Test script with different CLI flags
-- [ ] Verify behavior matches input arguments
-- [ ] Test help message with `--help` flag
-- [ ] Add validation for required arguments
+- [x] Add command-line argument parsing using `argparse`
+- [x] Add `--bucket` argument for GCS bucket name
+- [x] Add `--output_dir` argument for output directory path
+- [x] Add `--verbose` or logging level arguments
+- [x] Set up logging configuration based on verbosity level
+- [x] Add `--help` message with usage instructions
+- [x] Test script with different CLI flags
+- [x] Verify behavior matches input arguments
+- [x] Test help message with `--help` flag
+- [x] Add validation for required arguments


### PR DESCRIPTION
**What it accomplishes:**
Adds user-facing command-line arguments to set GCS bucket name, output directory, and logging level.

**How to verify:**

* Run the script with different CLI flags.
* Confirm that behavior (paths, verbosity) matches input.
* Add a help message and test with `--help`.

--
Adds a user-facing CLI interface for processing rrweb session data from a GCS bucket. The key changes include:

- Enhancing the prompt plan (prompt_plan.md) with a detailed CLI prompt and usage examples.
- Implementing CLI argument parsing, logging configuration, and error handling in process_rrweb_sessions.py.
- Introducing a new guidance file (docs/prompts/implement_step.md) for project task instructions.