### PR TITLE
Input Ingestion & Preprocessing: Event Classification

### DIFF
--- a/docs/prompts/detailed_prompt_for_step.md
+++ b/docs/prompts/detailed_prompt_for_step.md
@@ -1,0 +1,1 @@
+For Step <STEP_NUMBER> of the <MODULE_NAME> module: <STEP_DESCRIPTION>, can you provide a prompt that you would give a coding agent to ask it to do this?

--- a/rrweb_feature_extraction/preprocessing_prompt_plan.md
+++ b/rrweb_feature_extraction/preprocessing_prompt_plan.md
@@ -84,6 +84,37 @@ You’re implementing the **JSON Loader & Sorter** for the Input Ingestion modul
 * Tests cover events of each `type` and assert correct bucket placement
 * Edge case: empty event list yields three empty buckets
 
+**Prompt for Coding Agent:**
+
+You’re implementing **Event Classification** for the Input Ingestion module.
+
+**Tasks:**
+
+1. Create a new file `rrweb_ingest/classifier.py`.
+2. In this file, implement a function `classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[dict]]` that:
+   * Accepts a **sorted** list of rrweb event dicts.
+   * Splits them into three lists:
+     * **`snapshots`**: all events where `event["type"] == 2` (FullSnapshot)
+     * **`interactions`**: all events where `event["type"] == 3` (IncrementalSnapshot)
+     * **`others`**: all remaining events
+   * Returns `(snapshots, interactions, others)` in that exact order.
+3. Add a module-level docstring and inline comments to explain classification logic.
+
+**Testing:**
+
+1. Create `rrweb_ingest/tests/test_classifier.py`.
+2. Write unit tests to cover:
+
+   * An empty event list returns three empty lists.
+   * A mixed list of events with types 2, 3, and other values correctly populates each bucket.
+   * Events with unexpected or missing `type` keys raise a `KeyError`.
+
+**Verification Criteria:**
+
+* All tests in `test_classifier.py` pass under `pytest`.
+* The function signature and return order match the spec.
+* Existing loader tests and smoke tests remain green.
+
 ---
 
 ## 4. Basic Chunk Segmentation

--- a/rrweb_feature_extraction/preprocessing_todo.md
+++ b/rrweb_feature_extraction/preprocessing_todo.md
@@ -34,16 +34,16 @@
 ## Step 3: Event Classification
 
 ### Tasks:
-- [ ] Implement `classify_events(events)` function in `rrweb_ingest/classifier.py`
-- [ ] Create logic to separate events by `type` field:
-  - [ ] `type == 2` → snapshots (FullSnapshot)
-  - [ ] `type == 3` → interactions (IncrementalSnapshot)
-  - [ ] All other types → others (Meta, Custom, Plugin, etc.)
-- [ ] Return tuple of `(snapshots, interactions, others)` lists
-- [ ] Write unit tests for each event type classification
-- [ ] Test with mixed event types to verify correct bucketing
-- [ ] Test edge case: empty event list returns three empty lists
-- [ ] Verify no events are lost or duplicated during classification
+- [x] Implement `classify_events(events)` function in `rrweb_ingest/classifier.py`
+- [x] Create logic to separate events by `type` field:
+  - [x] `type == 2` → snapshots (FullSnapshot)
+  - [x] `type == 3` → interactions (IncrementalSnapshot)
+  - [x] All other types → others (Meta, Custom, Plugin, etc.)
+- [x] Return tuple of `(snapshots, interactions, others)` lists
+- [x] Write unit tests for each event type classification
+- [x] Test with mixed event types to verify correct bucketing
+- [x] Test edge case: empty event list returns three empty lists
+- [x] Verify no events are lost or duplicated during classification
 - [ ] Add logging for classification statistics
 
 ## Step 4: Basic Chunk Segmentation

--- a/rrweb_feature_extraction/rrweb_ingest/classifier.py
+++ b/rrweb_feature_extraction/rrweb_ingest/classifier.py
@@ -16,7 +16,7 @@ def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[di
     Takes a sorted list of rrweb event dictionaries and separates them into three
     categories based on their 'type' field:
     - Snapshots: Full DOM snapshots (type == 2)
-    - Interactions: Incremental changes (type == 3) 
+    - Interactions: Incremental changes (type == 3)
     - Others: All remaining event types (Meta, Custom, Plugin, etc.)
 
     Args:
@@ -35,7 +35,7 @@ def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[di
     for event in events:
         # Access 'type' field - will raise KeyError if missing
         event_type = event["type"]
-        
+
         if event_type == 2:
             # FullSnapshot events - complete DOM captures
             snapshots.append(event)

--- a/rrweb_feature_extraction/rrweb_ingest/classifier.py
+++ b/rrweb_feature_extraction/rrweb_ingest/classifier.py
@@ -1,0 +1,49 @@
+"""
+Event Classification for rrweb session data.
+
+This module provides functionality to classify rrweb events into different categories
+based on their type field. Events are separated into snapshots (full DOM captures),
+interactions (incremental changes), and other event types for downstream processing.
+"""
+
+from typing import List, Tuple
+
+
+def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[dict]]:
+    """
+    Classify rrweb events into snapshots, interactions, and others based on event type.
+
+    Takes a sorted list of rrweb event dictionaries and separates them into three
+    categories based on their 'type' field:
+    - Snapshots: Full DOM snapshots (type == 2)
+    - Interactions: Incremental changes (type == 3) 
+    - Others: All remaining event types (Meta, Custom, Plugin, etc.)
+
+    Args:
+        events: List of rrweb event dictionaries, typically sorted by timestamp
+
+    Returns:
+        Tuple containing three lists in order: (snapshots, interactions, others)
+
+    Raises:
+        KeyError: If any event is missing the required 'type' field
+    """
+    snapshots = []
+    interactions = []
+    others = []
+
+    for event in events:
+        # Access 'type' field - will raise KeyError if missing
+        event_type = event["type"]
+        
+        if event_type == 2:
+            # FullSnapshot events - complete DOM captures
+            snapshots.append(event)
+        elif event_type == 3:
+            # IncrementalSnapshot events - DOM mutations, mouse moves, inputs, etc.
+            interactions.append(event)
+        else:
+            # All other event types (Meta, Custom, Plugin, etc.)
+            others.append(event)
+
+    return snapshots, interactions, others

--- a/rrweb_feature_extraction/rrweb_ingest/tests/test_classifier.py
+++ b/rrweb_feature_extraction/rrweb_ingest/tests/test_classifier.py
@@ -12,10 +12,10 @@ from rrweb_ingest.classifier import classify_events
 def test_classify_empty_event_list():
     """Test that an empty event list returns three empty lists."""
     snapshots, interactions, others = classify_events([])
-    
-    assert snapshots == []
-    assert interactions == []
-    assert others == []
+
+    assert not snapshots
+    assert not interactions
+    assert not others
 
 
 def test_classify_mixed_event_types():
@@ -29,23 +29,23 @@ def test_classify_mixed_event_types():
         {"type": 3, "timestamp": 6000, "data": {"source": "interaction2"}},
         {"type": 4, "timestamp": 7000, "data": {"source": "plugin"}},
     ]
-    
+
     snapshots, interactions, others = classify_events(events)
-    
+
     # Verify snapshots (type == 2)
     assert len(snapshots) == 2
     assert snapshots[0]["type"] == 2
     assert snapshots[0]["data"]["source"] == "snapshot"
     assert snapshots[1]["type"] == 2
     assert snapshots[1]["data"]["source"] == "snapshot2"
-    
+
     # Verify interactions (type == 3)
     assert len(interactions) == 2
     assert interactions[0]["type"] == 3
     assert interactions[0]["data"]["source"] == "interaction"
     assert interactions[1]["type"] == 3
     assert interactions[1]["data"]["source"] == "interaction2"
-    
+
     # Verify others (all other types)
     assert len(others) == 3
     assert others[0]["type"] == 0
@@ -56,46 +56,13 @@ def test_classify_mixed_event_types():
     assert others[2]["data"]["source"] == "plugin"
 
 
-def test_classify_single_event_type():
-    """Test classification when all events are of the same type."""
-    # Test all snapshots
-    snapshot_events = [
-        {"type": 2, "timestamp": 1000, "data": {}},
-        {"type": 2, "timestamp": 2000, "data": {}},
-    ]
-    snapshots, interactions, others = classify_events(snapshot_events)
-    assert len(snapshots) == 2
-    assert len(interactions) == 0
-    assert len(others) == 0
-    
-    # Test all interactions
-    interaction_events = [
-        {"type": 3, "timestamp": 1000, "data": {}},
-        {"type": 3, "timestamp": 2000, "data": {}},
-    ]
-    snapshots, interactions, others = classify_events(interaction_events)
-    assert len(snapshots) == 0
-    assert len(interactions) == 2
-    assert len(others) == 0
-    
-    # Test all others
-    other_events = [
-        {"type": 0, "timestamp": 1000, "data": {}},
-        {"type": 1, "timestamp": 2000, "data": {}},
-    ]
-    snapshots, interactions, others = classify_events(other_events)
-    assert len(snapshots) == 0
-    assert len(interactions) == 0
-    assert len(others) == 2
-
-
 def test_classify_missing_type_field():
     """Test that events missing the 'type' field raise KeyError."""
     events_missing_type = [
         {"timestamp": 1000, "data": {"source": "no_type"}},
         {"type": 2, "timestamp": 2000, "data": {"source": "has_type"}},
     ]
-    
+
     with pytest.raises(KeyError):
         classify_events(events_missing_type)
 
@@ -107,9 +74,9 @@ def test_classify_unexpected_type_values():
         {"type": -1, "timestamp": 2000, "data": {}},
         {"type": "string", "timestamp": 3000, "data": {}},
     ]
-    
+
     snapshots, interactions, others = classify_events(events_with_unusual_types)
-    
+
     assert len(snapshots) == 0
     assert len(interactions) == 0
     assert len(others) == 3
@@ -127,9 +94,9 @@ def test_classify_preserves_event_order():
         {"type": 3, "timestamp": 4000, "data": {"id": "int2"}},
         {"type": 0, "timestamp": 5000, "data": {"id": "other1"}},
     ]
-    
+
     snapshots, interactions, others = classify_events(events)
-    
+
     # Verify order is preserved within each category
     assert snapshots[0]["data"]["id"] == "snap1"
     assert snapshots[1]["data"]["id"] == "snap2"

--- a/rrweb_feature_extraction/rrweb_ingest/tests/test_classifier.py
+++ b/rrweb_feature_extraction/rrweb_ingest/tests/test_classifier.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for the event classifier module.
+
+Tests the classify_events function to ensure proper categorization of rrweb events
+into snapshots, interactions, and others based on event type.
+"""
+
+import pytest
+from rrweb_ingest.classifier import classify_events
+
+
+def test_classify_empty_event_list():
+    """Test that an empty event list returns three empty lists."""
+    snapshots, interactions, others = classify_events([])
+    
+    assert snapshots == []
+    assert interactions == []
+    assert others == []
+
+
+def test_classify_mixed_event_types():
+    """Test that mixed event types are correctly classified into appropriate buckets."""
+    events = [
+        {"type": 2, "timestamp": 1000, "data": {"source": "snapshot"}},
+        {"type": 3, "timestamp": 2000, "data": {"source": "interaction"}},
+        {"type": 0, "timestamp": 3000, "data": {"source": "meta"}},
+        {"type": 2, "timestamp": 4000, "data": {"source": "snapshot2"}},
+        {"type": 1, "timestamp": 5000, "data": {"source": "custom"}},
+        {"type": 3, "timestamp": 6000, "data": {"source": "interaction2"}},
+        {"type": 4, "timestamp": 7000, "data": {"source": "plugin"}},
+    ]
+    
+    snapshots, interactions, others = classify_events(events)
+    
+    # Verify snapshots (type == 2)
+    assert len(snapshots) == 2
+    assert snapshots[0]["type"] == 2
+    assert snapshots[0]["data"]["source"] == "snapshot"
+    assert snapshots[1]["type"] == 2
+    assert snapshots[1]["data"]["source"] == "snapshot2"
+    
+    # Verify interactions (type == 3)
+    assert len(interactions) == 2
+    assert interactions[0]["type"] == 3
+    assert interactions[0]["data"]["source"] == "interaction"
+    assert interactions[1]["type"] == 3
+    assert interactions[1]["data"]["source"] == "interaction2"
+    
+    # Verify others (all other types)
+    assert len(others) == 3
+    assert others[0]["type"] == 0
+    assert others[0]["data"]["source"] == "meta"
+    assert others[1]["type"] == 1
+    assert others[1]["data"]["source"] == "custom"
+    assert others[2]["type"] == 4
+    assert others[2]["data"]["source"] == "plugin"
+
+
+def test_classify_single_event_type():
+    """Test classification when all events are of the same type."""
+    # Test all snapshots
+    snapshot_events = [
+        {"type": 2, "timestamp": 1000, "data": {}},
+        {"type": 2, "timestamp": 2000, "data": {}},
+    ]
+    snapshots, interactions, others = classify_events(snapshot_events)
+    assert len(snapshots) == 2
+    assert len(interactions) == 0
+    assert len(others) == 0
+    
+    # Test all interactions
+    interaction_events = [
+        {"type": 3, "timestamp": 1000, "data": {}},
+        {"type": 3, "timestamp": 2000, "data": {}},
+    ]
+    snapshots, interactions, others = classify_events(interaction_events)
+    assert len(snapshots) == 0
+    assert len(interactions) == 2
+    assert len(others) == 0
+    
+    # Test all others
+    other_events = [
+        {"type": 0, "timestamp": 1000, "data": {}},
+        {"type": 1, "timestamp": 2000, "data": {}},
+    ]
+    snapshots, interactions, others = classify_events(other_events)
+    assert len(snapshots) == 0
+    assert len(interactions) == 0
+    assert len(others) == 2
+
+
+def test_classify_missing_type_field():
+    """Test that events missing the 'type' field raise KeyError."""
+    events_missing_type = [
+        {"timestamp": 1000, "data": {"source": "no_type"}},
+        {"type": 2, "timestamp": 2000, "data": {"source": "has_type"}},
+    ]
+    
+    with pytest.raises(KeyError):
+        classify_events(events_missing_type)
+
+
+def test_classify_unexpected_type_values():
+    """Test that events with unexpected type values are placed in 'others'."""
+    events_with_unusual_types = [
+        {"type": 99, "timestamp": 1000, "data": {}},
+        {"type": -1, "timestamp": 2000, "data": {}},
+        {"type": "string", "timestamp": 3000, "data": {}},
+    ]
+    
+    snapshots, interactions, others = classify_events(events_with_unusual_types)
+    
+    assert len(snapshots) == 0
+    assert len(interactions) == 0
+    assert len(others) == 3
+    assert others[0]["type"] == 99
+    assert others[1]["type"] == -1
+    assert others[2]["type"] == "string"
+
+
+def test_classify_preserves_event_order():
+    """Test that events maintain their relative order within each category."""
+    events = [
+        {"type": 2, "timestamp": 1000, "data": {"id": "snap1"}},
+        {"type": 3, "timestamp": 2000, "data": {"id": "int1"}},
+        {"type": 2, "timestamp": 3000, "data": {"id": "snap2"}},
+        {"type": 3, "timestamp": 4000, "data": {"id": "int2"}},
+        {"type": 0, "timestamp": 5000, "data": {"id": "other1"}},
+    ]
+    
+    snapshots, interactions, others = classify_events(events)
+    
+    # Verify order is preserved within each category
+    assert snapshots[0]["data"]["id"] == "snap1"
+    assert snapshots[1]["data"]["id"] == "snap2"
+    assert interactions[0]["data"]["id"] == "int1"
+    assert interactions[1]["data"]["id"] == "int2"
+    assert others[0]["data"]["id"] == "other1"


### PR DESCRIPTION
**Goal:** Add `classify_events(events)` to split into `snapshots`, `interactions`, and `others`.
**Accomplishes:**

* Iterate sorted events, assign to three buckets based on `type`
* Return a tuple `(snapshots, interactions, others)`
  **Verification:**
* Tests cover events of each `type` and assert correct bucket placement
* Edge case: empty event list yields three empty buckets
