### PR TITLE
Basic Chunk Segmentation

### DIFF
--- a/rrweb_feature_extraction/preprocessing_prompt_plan.md
+++ b/rrweb_feature_extraction/preprocessing_prompt_plan.md
@@ -128,6 +128,48 @@ You’re implementing **Event Classification** for the Input Ingestion module.
 * Given synthetic interactions and snapshot events, assert chunk boundaries match snapshot positions
 * No dropped or merged events beyond boundaries
 
+**Prompt for Coding Agent:**
+
+You’re implementing **Basic Chunk Segmentation** for the Input Ingestion module.
+
+**Tasks:**
+
+1. Create a new file `rrweb_ingest/segmenter.py`.
+2. Implement a function
+   ```python
+   def segment_into_chunks(
+       interactions: List[dict],
+       snapshots: List[dict]
+   ) -> List[List[dict]]:
+       ...
+   ```
+   that:
+   * Accepts two sorted lists of rrweb events:
+
+     * `interactions`: events where `type == 3`.
+     * `snapshots`: events where `type == 2`.
+   * Iterates through `interactions`, starting a new chunk whenever:
+
+     1. The timestamp of the next interaction meets or exceeds the next `FullSnapshot` timestamp.
+     2. After crossing that boundary, uses subsequent snapshots in order.
+   * Returns a list of chunks, where each chunk is a list of contiguous interaction events between snapshot boundaries.
+3. Add docstrings that describe inputs, outputs, and the snapshot-boundary logic.
+
+**Testing:**
+
+1. Create `tests/test_segmenter.py`.
+2. Write unit tests to cover:
+   * No interactions and no snapshots → returns an empty list.
+   * Interactions but no snapshots → returns a single chunk containing all interactions.
+   * Multiple snapshots interleaved with interactions → splits interactions into the correct number of chunks at each snapshot timestamp.
+   * Edge case where an interaction event timestamp exactly equals a snapshot timestamp → ensure boundary logic is consistent (e.g., interaction goes into the new chunk).
+
+**Verification Criteria:**
+
+* All tests in `test_segmenter.py` pass under `pytest`.
+* Calling `segment_into_chunks` with sample data yields the expected chunk boundaries.
+* No existing tests are broken by this change.
+
 ---
 
 ## 5. Time‐Gap & Size‐Cap Chunking

--- a/rrweb_feature_extraction/preprocessing_todo.md
+++ b/rrweb_feature_extraction/preprocessing_todo.md
@@ -11,8 +11,8 @@
 - [x] Write basic smoke test in `tests/test_smoke.py` that imports `rrweb_ingest`
 - [x] Create CI configuration file (`.github/workflows/ci.yml` or equivalent)
 - [x] Configure CI to install dependencies and run pytest
-- [ ] Verify pytest runs successfully with smoke test
-- [ ] Test CI pipeline locally or in CI environment
+- [x] Verify pytest runs successfully with smoke test
+- [x] Test CI pipeline locally or in CI environment
 - [ ] Add basic project documentation structure
 
 ## Step 2: JSON Loader & Sorter
@@ -28,7 +28,7 @@
 - [x] Write unit tests for valid JSON loading and sorting
 - [x] Write unit tests for malformed JSON error cases
 - [x] Write unit tests for missing field validation
-- [ ] Test with sample rrweb JSON files
+- [x] Test with sample rrweb JSON files
 - [x] Verify correct timestamp sorting behavior
 
 ## Step 3: Event Classification

--- a/rrweb_feature_extraction/preprocessing_todo.md
+++ b/rrweb_feature_extraction/preprocessing_todo.md
@@ -49,15 +49,15 @@
 ## Step 4: Basic Chunk Segmentation
 
 ### Tasks:
-- [ ] Implement `segment_into_chunks(interactions, snapshots)` in `rrweb_ingest/segmenter.py`
-- [ ] Create logic to start new chunks at FullSnapshot boundaries
-- [ ] Iterate through interactions and group by snapshot timestamps
-- [ ] Handle case where no snapshots exist
-- [ ] Return list of raw interaction event lists (chunks)
-- [ ] Write unit tests with synthetic interaction and snapshot data
-- [ ] Test chunk boundaries align with snapshot positions
-- [ ] Verify no events are dropped during segmentation
-- [ ] Test edge cases: no snapshots, no interactions, single events
+- [x] Implement `segment_into_chunks(interactions, snapshots)` in `rrweb_ingest/segmenter.py`
+- [x] Create logic to start new chunks at FullSnapshot boundaries
+- [x] Iterate through interactions and group by snapshot timestamps
+- [x] Handle case where no snapshots exist
+- [x] Return list of raw interaction event lists (chunks)
+- [x] Write unit tests with synthetic interaction and snapshot data
+- [x] Test chunk boundaries align with snapshot positions
+- [x] Verify no events are dropped during segmentation
+- [x] Test edge cases: no snapshots, no interactions, single events
 - [ ] Add logging for chunk count and sizes
 
 ## Step 5: Time-Gap & Size-Cap Chunking

--- a/rrweb_feature_extraction/rrweb_ingest/segmenter.py
+++ b/rrweb_feature_extraction/rrweb_ingest/segmenter.py
@@ -1,0 +1,80 @@
+"""
+Basic Chunk Segmentation for rrweb session data.
+
+This module provides functionality to segment interaction events into logical chunks
+based on FullSnapshot boundaries. Chunks represent meaningful units of user activity
+that can be processed independently for feature extraction.
+"""
+
+from typing import List
+
+
+def segment_into_chunks(
+    interactions: List[dict], snapshots: List[dict]
+) -> List[List[dict]]:
+    """
+    Segment interaction events into chunks based on FullSnapshot boundaries.
+
+    Takes sorted lists of interaction events (type == 3) and snapshot events (type == 2)
+    and groups interactions into chunks. A new chunk is started whenever an interaction's
+    timestamp meets or exceeds the next FullSnapshot timestamp.
+
+    Args:
+        interactions: List of interaction events (type == 3) sorted by timestamp
+        snapshots: List of snapshot events (type == 2) sorted by timestamp
+
+    Returns:
+        List of chunks, where each chunk is a list of contiguous interaction events
+        between snapshot boundaries. If no snapshots exist, returns a single chunk
+        containing all interactions. If no interactions exist, returns an empty list.
+
+    Example:
+        interactions = [
+            {"type": 3, "timestamp": 100, "data": {}},
+            {"type": 3, "timestamp": 200, "data": {}},
+            {"type": 3, "timestamp": 400, "data": {}},
+        ]
+        snapshots = [
+            {"type": 2, "timestamp": 150, "data": {}},
+            {"type": 2, "timestamp": 350, "data": {}},
+        ]
+        
+        Result: [
+            [{"type": 3, "timestamp": 100, "data": {}}],  # Before first snapshot
+            [{"type": 3, "timestamp": 200, "data": {}}],  # Between snapshots
+            [{"type": 3, "timestamp": 400, "data": {}}],  # After last snapshot
+        ]
+    """
+    # Handle edge cases
+    if not interactions:
+        return []
+    
+    if not snapshots:
+        return [interactions]
+    
+    chunks = []
+    current_chunk = []
+    snapshot_iter = iter(snapshots)
+    next_snapshot = next(snapshot_iter, None)
+    
+    for interaction in interactions:
+        interaction_timestamp = interaction["timestamp"]
+        
+        # Check if we need to start a new chunk due to snapshot boundary
+        while next_snapshot and interaction_timestamp >= next_snapshot["timestamp"]:
+            # Finish current chunk if it has events
+            if current_chunk:
+                chunks.append(current_chunk)
+                current_chunk = []
+            
+            # Move to next snapshot
+            next_snapshot = next(snapshot_iter, None)
+        
+        # Add interaction to current chunk
+        current_chunk.append(interaction)
+    
+    # Add final chunk if it has events
+    if current_chunk:
+        chunks.append(current_chunk)
+    
+    return chunks

--- a/rrweb_feature_extraction/rrweb_ingest/segmenter.py
+++ b/rrweb_feature_extraction/rrweb_ingest/segmenter.py
@@ -38,7 +38,7 @@ def segment_into_chunks(
             {"type": 2, "timestamp": 150, "data": {}},
             {"type": 2, "timestamp": 350, "data": {}},
         ]
-        
+
         Result: [
             [{"type": 3, "timestamp": 100, "data": {}}],  # Before first snapshot
             [{"type": 3, "timestamp": 200, "data": {}}],  # Between snapshots
@@ -48,33 +48,33 @@ def segment_into_chunks(
     # Handle edge cases
     if not interactions:
         return []
-    
+
     if not snapshots:
         return [interactions]
-    
+
     chunks = []
     current_chunk = []
     snapshot_iter = iter(snapshots)
     next_snapshot = next(snapshot_iter, None)
-    
+
     for interaction in interactions:
         interaction_timestamp = interaction["timestamp"]
-        
+
         # Check if we need to start a new chunk due to snapshot boundary
         while next_snapshot and interaction_timestamp >= next_snapshot["timestamp"]:
             # Finish current chunk if it has events
             if current_chunk:
                 chunks.append(current_chunk)
                 current_chunk = []
-            
+
             # Move to next snapshot
             next_snapshot = next(snapshot_iter, None)
-        
+
         # Add interaction to current chunk
         current_chunk.append(interaction)
-    
+
     # Add final chunk if it has events
     if current_chunk:
         chunks.append(current_chunk)
-    
+
     return chunks

--- a/rrweb_feature_extraction/rrweb_ingest/tests/test_segmenter.py
+++ b/rrweb_feature_extraction/rrweb_ingest/tests/test_segmenter.py
@@ -5,14 +5,13 @@ Tests the segment_into_chunks function to ensure proper segmentation of interact
 events based on FullSnapshot boundaries.
 """
 
-import pytest
 from rrweb_ingest.segmenter import segment_into_chunks
 
 
 def test_no_interactions_no_snapshots():
     """Test that empty inputs return an empty list."""
     result = segment_into_chunks([], [])
-    assert result == []
+    assert not result
 
 
 def test_no_interactions_with_snapshots():
@@ -22,7 +21,7 @@ def test_no_interactions_with_snapshots():
         {"type": 2, "timestamp": 2000, "data": {}},
     ]
     result = segment_into_chunks([], snapshots)
-    assert result == []
+    assert not result
 
 
 def test_interactions_no_snapshots():
@@ -32,9 +31,9 @@ def test_interactions_no_snapshots():
         {"type": 3, "timestamp": 200, "data": {"id": "int2"}},
         {"type": 3, "timestamp": 300, "data": {"id": "int3"}},
     ]
-    
+
     result = segment_into_chunks(interactions, [])
-    
+
     assert len(result) == 1
     assert result[0] == interactions
 
@@ -50,15 +49,15 @@ def test_single_snapshot_splits_interactions():
     snapshots = [
         {"type": 2, "timestamp": 300, "data": {"id": "snap1"}},
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
+
     assert len(result) == 2
     # First chunk: interactions before snapshot timestamp 300
     assert len(result[0]) == 2
     assert result[0][0]["data"]["id"] == "int1"  # timestamp 100
     assert result[0][1]["data"]["id"] == "int2"  # timestamp 200
-    
+
     # Second chunk: interactions at or after snapshot timestamp 300
     assert len(result[1]) == 2
     assert result[1][0]["data"]["id"] == "int3"  # timestamp 400
@@ -79,24 +78,24 @@ def test_multiple_snapshots_create_multiple_chunks():
         {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
         {"type": 2, "timestamp": 400, "data": {"id": "snap3"}},
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
-    assert len(result) == 4
-    
+
+    assert len(result) == len(snapshots) + 1
+
     # Chunk 1: before first snapshot (timestamp < 100)
     assert len(result[0]) == 1
     assert result[0][0]["data"]["id"] == "int1"  # timestamp 50
-    
+
     # Chunk 2: between first and second snapshot (100 <= timestamp < 200)
     assert len(result[1]) == 1
     assert result[1][0]["data"]["id"] == "int2"  # timestamp 150
-    
+
     # Chunk 3: between second and third snapshot (200 <= timestamp < 400)
     assert len(result[2]) == 2
     assert result[2][0]["data"]["id"] == "int3"  # timestamp 250
     assert result[2][1]["data"]["id"] == "int4"  # timestamp 350
-    
+
     # Chunk 4: after last snapshot (timestamp >= 400)
     assert len(result[3]) == 1
     assert result[3][0]["data"]["id"] == "int5"  # timestamp 450
@@ -112,15 +111,15 @@ def test_interaction_timestamp_equals_snapshot_timestamp():
     snapshots = [
         {"type": 2, "timestamp": 200, "data": {"id": "snap1"}},
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
+
     assert len(result) == 2
-    
+
     # First chunk: interactions before snapshot timestamp
     assert len(result[0]) == 1
     assert result[0][0]["data"]["id"] == "int1"  # timestamp 100
-    
+
     # Second chunk: interactions at or after snapshot timestamp (>= 200)
     assert len(result[1]) == 2
     assert result[1][0]["data"]["id"] == "int2"  # timestamp 200 (equals snapshot)
@@ -137,11 +136,11 @@ def test_all_interactions_before_snapshots():
         {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
         {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
+
     assert len(result) == 1
-    assert len(result[0]) == 2
+    assert len(result[0]) == len(interactions)
     assert result[0] == interactions
 
 
@@ -155,9 +154,9 @@ def test_all_interactions_after_snapshots():
         {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
         {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
+
     assert len(result) == 1
     assert len(result[0]) == 2
     assert result[0] == interactions
@@ -171,19 +170,27 @@ def test_consecutive_snapshots_create_empty_chunks():
     ]
     snapshots = [
         {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
-        {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},  # No interactions between 100-200
-        {"type": 2, "timestamp": 300, "data": {"id": "snap3"}},  # No interactions between 200-300
+        {
+            "type": 2,
+            "timestamp": 200,
+            "data": {"id": "snap2"},
+        },  # No interactions between 100-200
+        {
+            "type": 2,
+            "timestamp": 300,
+            "data": {"id": "snap3"},
+        },  # No interactions between 200-300
     ]
-    
+
     result = segment_into_chunks(interactions, snapshots)
-    
+
     # Should only create chunks where there are actual interactions
     assert len(result) == 2
-    
+
     # First chunk: before first snapshot
     assert len(result[0]) == 1
     assert result[0][0]["data"]["id"] == "int1"  # timestamp 50
-    
+
     # Second chunk: after all snapshots
     assert len(result[1]) == 1
     assert result[1][0]["data"]["id"] == "int2"  # timestamp 350

--- a/rrweb_feature_extraction/rrweb_ingest/tests/test_segmenter.py
+++ b/rrweb_feature_extraction/rrweb_ingest/tests/test_segmenter.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for the segmenter module.
+
+Tests the segment_into_chunks function to ensure proper segmentation of interaction
+events based on FullSnapshot boundaries.
+"""
+
+import pytest
+from rrweb_ingest.segmenter import segment_into_chunks
+
+
+def test_no_interactions_no_snapshots():
+    """Test that empty inputs return an empty list."""
+    result = segment_into_chunks([], [])
+    assert result == []
+
+
+def test_no_interactions_with_snapshots():
+    """Test that no interactions with snapshots returns an empty list."""
+    snapshots = [
+        {"type": 2, "timestamp": 1000, "data": {}},
+        {"type": 2, "timestamp": 2000, "data": {}},
+    ]
+    result = segment_into_chunks([], snapshots)
+    assert result == []
+
+
+def test_interactions_no_snapshots():
+    """Test that interactions without snapshots returns a single chunk."""
+    interactions = [
+        {"type": 3, "timestamp": 100, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 200, "data": {"id": "int2"}},
+        {"type": 3, "timestamp": 300, "data": {"id": "int3"}},
+    ]
+    
+    result = segment_into_chunks(interactions, [])
+    
+    assert len(result) == 1
+    assert result[0] == interactions
+
+
+def test_single_snapshot_splits_interactions():
+    """Test that a single snapshot correctly splits interactions."""
+    interactions = [
+        {"type": 3, "timestamp": 100, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 200, "data": {"id": "int2"}},
+        {"type": 3, "timestamp": 400, "data": {"id": "int3"}},
+        {"type": 3, "timestamp": 500, "data": {"id": "int4"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 300, "data": {"id": "snap1"}},
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    assert len(result) == 2
+    # First chunk: interactions before snapshot timestamp 300
+    assert len(result[0]) == 2
+    assert result[0][0]["data"]["id"] == "int1"  # timestamp 100
+    assert result[0][1]["data"]["id"] == "int2"  # timestamp 200
+    
+    # Second chunk: interactions at or after snapshot timestamp 300
+    assert len(result[1]) == 2
+    assert result[1][0]["data"]["id"] == "int3"  # timestamp 400
+    assert result[1][1]["data"]["id"] == "int4"  # timestamp 500
+
+
+def test_multiple_snapshots_create_multiple_chunks():
+    """Test that multiple snapshots create the correct number of chunks."""
+    interactions = [
+        {"type": 3, "timestamp": 50, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 150, "data": {"id": "int2"}},
+        {"type": 3, "timestamp": 250, "data": {"id": "int3"}},
+        {"type": 3, "timestamp": 350, "data": {"id": "int4"}},
+        {"type": 3, "timestamp": 450, "data": {"id": "int5"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
+        {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
+        {"type": 2, "timestamp": 400, "data": {"id": "snap3"}},
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    assert len(result) == 4
+    
+    # Chunk 1: before first snapshot (timestamp < 100)
+    assert len(result[0]) == 1
+    assert result[0][0]["data"]["id"] == "int1"  # timestamp 50
+    
+    # Chunk 2: between first and second snapshot (100 <= timestamp < 200)
+    assert len(result[1]) == 1
+    assert result[1][0]["data"]["id"] == "int2"  # timestamp 150
+    
+    # Chunk 3: between second and third snapshot (200 <= timestamp < 400)
+    assert len(result[2]) == 2
+    assert result[2][0]["data"]["id"] == "int3"  # timestamp 250
+    assert result[2][1]["data"]["id"] == "int4"  # timestamp 350
+    
+    # Chunk 4: after last snapshot (timestamp >= 400)
+    assert len(result[3]) == 1
+    assert result[3][0]["data"]["id"] == "int5"  # timestamp 450
+
+
+def test_interaction_timestamp_equals_snapshot_timestamp():
+    """Test boundary condition where interaction timestamp equals snapshot timestamp."""
+    interactions = [
+        {"type": 3, "timestamp": 100, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 200, "data": {"id": "int2"}},  # Equals snapshot
+        {"type": 3, "timestamp": 300, "data": {"id": "int3"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 200, "data": {"id": "snap1"}},
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    assert len(result) == 2
+    
+    # First chunk: interactions before snapshot timestamp
+    assert len(result[0]) == 1
+    assert result[0][0]["data"]["id"] == "int1"  # timestamp 100
+    
+    # Second chunk: interactions at or after snapshot timestamp (>= 200)
+    assert len(result[1]) == 2
+    assert result[1][0]["data"]["id"] == "int2"  # timestamp 200 (equals snapshot)
+    assert result[1][1]["data"]["id"] == "int3"  # timestamp 300
+
+
+def test_all_interactions_before_snapshots():
+    """Test case where all interactions occur before any snapshots."""
+    interactions = [
+        {"type": 3, "timestamp": 50, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 75, "data": {"id": "int2"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
+        {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    assert len(result) == 1
+    assert len(result[0]) == 2
+    assert result[0] == interactions
+
+
+def test_all_interactions_after_snapshots():
+    """Test case where all interactions occur after all snapshots."""
+    interactions = [
+        {"type": 3, "timestamp": 300, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 400, "data": {"id": "int2"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
+        {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    assert len(result) == 1
+    assert len(result[0]) == 2
+    assert result[0] == interactions
+
+
+def test_consecutive_snapshots_create_empty_chunks():
+    """Test that consecutive snapshots don't create empty chunks."""
+    interactions = [
+        {"type": 3, "timestamp": 50, "data": {"id": "int1"}},
+        {"type": 3, "timestamp": 350, "data": {"id": "int2"}},
+    ]
+    snapshots = [
+        {"type": 2, "timestamp": 100, "data": {"id": "snap1"}},
+        {"type": 2, "timestamp": 200, "data": {"id": "snap2"}},  # No interactions between 100-200
+        {"type": 2, "timestamp": 300, "data": {"id": "snap3"}},  # No interactions between 200-300
+    ]
+    
+    result = segment_into_chunks(interactions, snapshots)
+    
+    # Should only create chunks where there are actual interactions
+    assert len(result) == 2
+    
+    # First chunk: before first snapshot
+    assert len(result[0]) == 1
+    assert result[0][0]["data"]["id"] == "int1"  # timestamp 50
+    
+    # Second chunk: after all snapshots
+    assert len(result[1]) == 1
+    assert result[1][0]["data"]["id"] == "int2"  # timestamp 350


### PR DESCRIPTION
**Goal:** Implement `segment_into_chunks(interactions, snapshots)` that creates preliminary chunks at snapshot boundaries.
**Accomplishes:**

* Iterate `interactions`, start new chunk whenever hitting a `FullSnapshot` timestamp
* Produce a list of raw interaction lists
  **Verification:**
* Given synthetic interactions and snapshot events, assert chunk boundaries match snapshot positions
* No dropped or merged events beyond boundaries

--
Implements basic chunk segmentation by splitting interaction events at FullSnapshot boundaries and adds thorough unit tests to verify behavior.

- Introduces segment_into_chunks in rrweb_feature_extraction/rrweb_ingest/segmenter.py to group interactions into chunks when crossing snapshot timestamps.
- Adds test_segmenter.py covering normal cases, boundary conditions, and edge scenarios.