### PR TITLE
Skip the deployment and E2E tests if only modifying rrweb_feature_extraction, session_stitching, test_gen, & docs folders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,11 @@
 def GAR_HOST = 'us-east4-docker.pkg.dev'
 def GAR_REPO = "${GAR_HOST}/${env.GCP_PROJECT}/default-gar"
 
-def SERVER_IP = null
+// Variable defined later in the pipeline
 def HELM_DEPLOY_NAME = null
+def RUN_INTEGRATION_TESTS = true
+def SANITIZED_BUILD_TAG = null
+def SERVER_IP = null
 
 pipeline {
     agent none

--- a/jenkins/changesetHelper.groovy
+++ b/jenkins/changesetHelper.groovy
@@ -1,3 +1,14 @@
+/**
+ * Helper functions for working with change sets in Jenkins pipelines.
+ */
+
+/**
+ * Get the list of changed files in the current branch compared to main.
+ * This function fetches the latest changes from the main branch and returns
+ * a list of files that have been modified, added, or deleted.
+ *
+ * @return List of changed files.
+ */
 def getChangeSetToTest() {
     // Fetch main so that it's available to diff against
     sh 'git fetch origin refs/heads/main:refs/remotes/origin/main'

--- a/jenkins/stagesHelper.groovy
+++ b/jenkins/stagesHelper.groovy
@@ -1,3 +1,12 @@
+/**
+ * This script is used in Jenkins pipelines to determine whether integration tests should be run
+ */
+
+/**
+ * Check if integration tests should be run based on the changed files in the current branch.
+ * Run the integration tests if the branch is 'main' or if there are any changes in files that
+ * are not in the excluded directories.
+ */
 def shouldRunIntegrationTests(changeSet) {
     if (BRANCH_NAME == 'main') {
         return true


### PR DESCRIPTION
Since these folders don't impact the production code or test infrastructure, let's skip the E2E tests when modifying them for a faster iteration loop.

--
Optimizes the Jenkins pipeline by skipping integration/E2E test stages when specific folders are modified, improving iteration speed.

- Added helper scripts to fetch and filter the Git change set.
- Introduced shouldRunIntegrationTests logic based on excluded directories.
- Updated the Jenkinsfile to conditionally run integration tests.