### PR TITLE
Virtual DOM State Initialization

### DIFF
--- a/test_gen/docs/feature_extraction/todo.md
+++ b/test_gen/docs/feature_extraction/todo.md
@@ -25,20 +25,20 @@
 ## Step 2: Virtual DOM State Initialization
 
 ### Tasks:
-- [ ] Create `test_gen/feature_extraction/dom_state.py`
-- [ ] Implement `init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]`:
-  - [ ] Handle rrweb events with `type == 2` and `data.node`
-  - [ ] Traverse snapshot payload to build node tree
-  - [ ] Extract node ID, tag, attributes, text content, parent ID
-  - [ ] Return dict mapping node IDs to UINode instances
-- [ ] Add module-level docstring explaining virtual DOM initialization
-- [ ] Create `test_gen/feature_extraction/tests/test_dom_state.py`:
-  - [ ] Test with synthetic FullSnapshot event and simple DOM tree
-  - [ ] Verify correct node_by_id dict with proper keys and UINode fields
-  - [ ] Test root node has parent = None
-  - [ ] Test node attributes and textContent captured exactly
-- [ ] Verify pytest passes without errors
-- [ ] Code review confirms correct snapshot traversal and UINode population
+- [x] Create `test_gen/feature_extraction/dom_state.py`
+- [x] Implement `init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]`:
+  - [x] Handle rrweb events with `type == 2` and `data.node`
+  - [x] Traverse snapshot payload to build node tree
+  - [x] Extract node ID, tag, attributes, text content, parent ID
+  - [x] Return dict mapping node IDs to UINode instances
+- [x] Add module-level docstring explaining virtual DOM initialization
+- [x] Create `test_gen/feature_extraction/tests/test_dom_state.py`:
+  - [x] Test with synthetic FullSnapshot event and simple DOM tree
+  - [x] Verify correct node_by_id dict with proper keys and UINode fields
+  - [x] Test root node has parent = None
+  - [x] Test node attributes and textContent captured exactly
+- [x] Verify pytest passes without errors
+- [x] Code review confirms correct snapshot traversal and UINode population
 
 ## Step 3: Virtual DOM Mutation Updates
 

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -13,57 +13,53 @@ from .models import UINode
 def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:
     """
     Given a FullSnapshot rrweb event, builds and returns a node_by_id map.
-    
+
     The full_snapshot_event is an rrweb event with type == 2 and data.node
     containing the entire DOM tree. This function traverses the snapshot
     payload and creates UINode instances for each DOM node.
-    
+
     Args:
         full_snapshot_event: rrweb event with type == 2 containing DOM snapshot
-        
+
     Returns:
         Dict mapping node IDs to UINode instances
-        
+
     Raises:
         ValueError: If the event is not a valid FullSnapshot event
     """
     if full_snapshot_event.get("type") != 2:
         raise ValueError("Event must be a FullSnapshot event (type == 2)")
-    
+
     if "data" not in full_snapshot_event or "node" not in full_snapshot_event["data"]:
         raise ValueError("FullSnapshot event must contain data.node")
-    
+
     node_by_id = {}
     root_node = full_snapshot_event["data"]["node"]
-    
+
     def traverse_node(node_data, parent_id=None):
         """Recursively traverse the DOM tree and create UINode instances."""
         node_id = node_data.get("id")
         if node_id is None:
             return
-        
+
         # Extract node properties
         tag = node_data.get("tagName", node_data.get("type", ""))
         attributes = node_data.get("attributes", {})
         text = node_data.get("textContent", "")
-        
+
         # Create UINode instance
         ui_node = UINode(
-            id=node_id,
-            tag=tag,
-            attributes=attributes,
-            text=text,
-            parent=parent_id
+            id=node_id, tag=tag, attributes=attributes, text=text, parent=parent_id
         )
-        
+
         node_by_id[node_id] = ui_node
-        
+
         # Recursively process child nodes
         child_nodes = node_data.get("childNodes", [])
         for child in child_nodes:
             traverse_node(child, node_id)
-    
+
     # Start traversal from root
     traverse_node(root_node)
-    
+
     return node_by_id

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -1,0 +1,69 @@
+"""
+Virtual DOM State Management for rrweb Session Feature Extraction.
+
+This module handles the initialization and maintenance of a virtual DOM state
+from rrweb snapshot and mutation events. It creates the initial DOM tree from
+FullSnapshot events and provides utilities for tracking DOM changes over time.
+"""
+
+from typing import Dict
+from .models import UINode
+
+
+def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:
+    """
+    Given a FullSnapshot rrweb event, builds and returns a node_by_id map.
+    
+    The full_snapshot_event is an rrweb event with type == 2 and data.node
+    containing the entire DOM tree. This function traverses the snapshot
+    payload and creates UINode instances for each DOM node.
+    
+    Args:
+        full_snapshot_event: rrweb event with type == 2 containing DOM snapshot
+        
+    Returns:
+        Dict mapping node IDs to UINode instances
+        
+    Raises:
+        ValueError: If the event is not a valid FullSnapshot event
+    """
+    if full_snapshot_event.get("type") != 2:
+        raise ValueError("Event must be a FullSnapshot event (type == 2)")
+    
+    if "data" not in full_snapshot_event or "node" not in full_snapshot_event["data"]:
+        raise ValueError("FullSnapshot event must contain data.node")
+    
+    node_by_id = {}
+    root_node = full_snapshot_event["data"]["node"]
+    
+    def traverse_node(node_data, parent_id=None):
+        """Recursively traverse the DOM tree and create UINode instances."""
+        node_id = node_data.get("id")
+        if node_id is None:
+            return
+        
+        # Extract node properties
+        tag = node_data.get("tagName", node_data.get("type", ""))
+        attributes = node_data.get("attributes", {})
+        text = node_data.get("textContent", "")
+        
+        # Create UINode instance
+        ui_node = UINode(
+            id=node_id,
+            tag=tag,
+            attributes=attributes,
+            text=text,
+            parent=parent_id
+        )
+        
+        node_by_id[node_id] = ui_node
+        
+        # Recursively process child nodes
+        child_nodes = node_data.get("childNodes", [])
+        for child in child_nodes:
+            traverse_node(child, node_id)
+    
+    # Start traversal from root
+    traverse_node(root_node)
+    
+    return node_by_id

--- a/test_gen/feature_extraction/tests/test_dom_state.py
+++ b/test_gen/feature_extraction/tests/test_dom_state.py
@@ -7,7 +7,6 @@ and the accurate population of UINode mappings.
 
 import pytest
 from feature_extraction.dom_state import init_dom_state
-from feature_extraction.models import UINode
 
 
 def test_init_dom_state_simple_tree():

--- a/test_gen/feature_extraction/tests/test_dom_state.py
+++ b/test_gen/feature_extraction/tests/test_dom_state.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for DOM state initialization and management.
+
+Tests the creation of virtual DOM state from rrweb FullSnapshot events
+and the accurate population of UINode mappings.
+"""
+
+import pytest
+from feature_extraction.dom_state import init_dom_state
+from feature_extraction.models import UINode
+
+
+def test_init_dom_state_simple_tree():
+    """Test initialization with a simple DOM tree (root with two children)."""
+    full_snapshot_event = {
+        "type": 2,
+        "data": {
+            "node": {
+                "id": 1,
+                "type": "Document",
+                "childNodes": [
+                    {
+                        "id": 2,
+                        "tagName": "html",
+                        "attributes": {"lang": "en"},
+                        "childNodes": [
+                            {
+                                "id": 3,
+                                "tagName": "body",
+                                "attributes": {"class": "main"},
+                                "textContent": "",
+                                "childNodes": []
+                            },
+                            {
+                                "id": 4,
+                                "tagName": "div",
+                                "attributes": {"id": "content"},
+                                "textContent": "Hello World",
+                                "childNodes": []
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+    
+    node_by_id = init_dom_state(full_snapshot_event)
+    
+    # Verify correct number of nodes
+    assert len(node_by_id) == 4
+    
+    # Verify root node
+    root_node = node_by_id[1]
+    assert root_node.id == 1
+    assert root_node.tag == "Document"
+    assert root_node.parent is None
+    assert root_node.attributes == {}
+    
+    # Verify html node
+    html_node = node_by_id[2]
+    assert html_node.id == 2
+    assert html_node.tag == "html"
+    assert html_node.parent == 1
+    assert html_node.attributes == {"lang": "en"}
+    
+    # Verify body node
+    body_node = node_by_id[3]
+    assert body_node.id == 3
+    assert body_node.tag == "body"
+    assert body_node.parent == 2
+    assert body_node.attributes == {"class": "main"}
+    assert body_node.text == ""
+    
+    # Verify div node
+    div_node = node_by_id[4]
+    assert div_node.id == 4
+    assert div_node.tag == "div"
+    assert div_node.parent == 2
+    assert div_node.attributes == {"id": "content"}
+    assert div_node.text == "Hello World"
+
+
+def test_init_dom_state_root_parent_is_none():
+    """Test that the root node's parent is None."""
+    full_snapshot_event = {
+        "type": 2,
+        "data": {
+            "node": {
+                "id": 1,
+                "type": "Document",
+                "childNodes": []
+            }
+        }
+    }
+    
+    node_by_id = init_dom_state(full_snapshot_event)
+    
+    root_node = node_by_id[1]
+    assert root_node.parent is None
+
+
+def test_init_dom_state_attributes_and_text_captured():
+    """Test that node attributes and textContent are captured exactly."""
+    full_snapshot_event = {
+        "type": 2,
+        "data": {
+            "node": {
+                "id": 1,
+                "tagName": "button",
+                "attributes": {
+                    "aria-label": "Submit Form",
+                    "class": "btn btn-primary",
+                    "data-testid": "submit-button",
+                    "role": "button"
+                },
+                "textContent": "Submit",
+                "childNodes": []
+            }
+        }
+    }
+    
+    node_by_id = init_dom_state(full_snapshot_event)
+    
+    button_node = node_by_id[1]
+    assert button_node.tag == "button"
+    assert button_node.attributes["aria-label"] == "Submit Form"
+    assert button_node.attributes["class"] == "btn btn-primary"
+    assert button_node.attributes["data-testid"] == "submit-button"
+    assert button_node.attributes["role"] == "button"
+    assert button_node.text == "Submit"
+
+
+def test_init_dom_state_empty_attributes():
+    """Test handling of nodes with no attributes."""
+    full_snapshot_event = {
+        "type": 2,
+        "data": {
+            "node": {
+                "id": 1,
+                "tagName": "div",
+                "childNodes": []
+            }
+        }
+    }
+    
+    node_by_id = init_dom_state(full_snapshot_event)
+    
+    div_node = node_by_id[1]
+    assert div_node.attributes == {}
+    assert div_node.text == ""
+
+
+def test_init_dom_state_invalid_event_type():
+    """Test that non-FullSnapshot events raise ValueError."""
+    invalid_event = {
+        "type": 3,  # Not a FullSnapshot
+        "data": {"source": 0}
+    }
+    
+    with pytest.raises(ValueError, match="Event must be a FullSnapshot event"):
+        init_dom_state(invalid_event)
+
+
+def test_init_dom_state_missing_data_node():
+    """Test that events without data.node raise ValueError."""
+    invalid_event = {
+        "type": 2,
+        "data": {}  # Missing node
+    }
+    
+    with pytest.raises(ValueError, match="FullSnapshot event must contain data.node"):
+        init_dom_state(invalid_event)
+
+
+def test_init_dom_state_missing_data():
+    """Test that events without data raise ValueError."""
+    invalid_event = {
+        "type": 2
+        # Missing data entirely
+    }
+    
+    with pytest.raises(ValueError, match="FullSnapshot event must contain data.node"):
+        init_dom_state(invalid_event)
+
+
+def test_init_dom_state_nodes_without_ids_ignored():
+    """Test that nodes without IDs are safely ignored."""
+    full_snapshot_event = {
+        "type": 2,
+        "data": {
+            "node": {
+                "id": 1,
+                "tagName": "div",
+                "childNodes": [
+                    {
+                        # Missing id - should be ignored
+                        "tagName": "span",
+                        "textContent": "No ID"
+                    },
+                    {
+                        "id": 2,
+                        "tagName": "p",
+                        "textContent": "Has ID"
+                    }
+                ]
+            }
+        }
+    }
+    
+    node_by_id = init_dom_state(full_snapshot_event)
+    
+    # Should only contain nodes with IDs
+    assert len(node_by_id) == 2
+    assert 1 in node_by_id
+    assert 2 in node_by_id
+    
+    # Verify the valid child node
+    p_node = node_by_id[2]
+    assert p_node.tag == "p"
+    assert p_node.text == "Has ID"
+    assert p_node.parent == 1

--- a/test_gen/feature_extraction/tests/test_dom_state.py
+++ b/test_gen/feature_extraction/tests/test_dom_state.py
@@ -29,41 +29,41 @@ def test_init_dom_state_simple_tree():
                                 "tagName": "body",
                                 "attributes": {"class": "main"},
                                 "textContent": "",
-                                "childNodes": []
+                                "childNodes": [],
                             },
                             {
                                 "id": 4,
                                 "tagName": "div",
                                 "attributes": {"id": "content"},
                                 "textContent": "Hello World",
-                                "childNodes": []
-                            }
-                        ]
+                                "childNodes": [],
+                            },
+                        ],
                     }
-                ]
+                ],
             }
-        }
+        },
     }
-    
+
     node_by_id = init_dom_state(full_snapshot_event)
-    
+
     # Verify correct number of nodes
     assert len(node_by_id) == 4
-    
+
     # Verify root node
     root_node = node_by_id[1]
     assert root_node.id == 1
     assert root_node.tag == "Document"
     assert root_node.parent is None
     assert root_node.attributes == {}
-    
+
     # Verify html node
     html_node = node_by_id[2]
     assert html_node.id == 2
     assert html_node.tag == "html"
     assert html_node.parent == 1
     assert html_node.attributes == {"lang": "en"}
-    
+
     # Verify body node
     body_node = node_by_id[3]
     assert body_node.id == 3
@@ -71,7 +71,7 @@ def test_init_dom_state_simple_tree():
     assert body_node.parent == 2
     assert body_node.attributes == {"class": "main"}
     assert body_node.text == ""
-    
+
     # Verify div node
     div_node = node_by_id[4]
     assert div_node.id == 4
@@ -85,17 +85,11 @@ def test_init_dom_state_root_parent_is_none():
     """Test that the root node's parent is None."""
     full_snapshot_event = {
         "type": 2,
-        "data": {
-            "node": {
-                "id": 1,
-                "type": "Document",
-                "childNodes": []
-            }
-        }
+        "data": {"node": {"id": 1, "type": "Document", "childNodes": []}},
     }
-    
+
     node_by_id = init_dom_state(full_snapshot_event)
-    
+
     root_node = node_by_id[1]
     assert root_node.parent is None
 
@@ -112,16 +106,16 @@ def test_init_dom_state_attributes_and_text_captured():
                     "aria-label": "Submit Form",
                     "class": "btn btn-primary",
                     "data-testid": "submit-button",
-                    "role": "button"
+                    "role": "button",
                 },
                 "textContent": "Submit",
-                "childNodes": []
+                "childNodes": [],
             }
-        }
+        },
     }
-    
+
     node_by_id = init_dom_state(full_snapshot_event)
-    
+
     button_node = node_by_id[1]
     assert button_node.tag == "button"
     assert button_node.attributes["aria-label"] == "Submit Form"
@@ -135,17 +129,11 @@ def test_init_dom_state_empty_attributes():
     """Test handling of nodes with no attributes."""
     full_snapshot_event = {
         "type": 2,
-        "data": {
-            "node": {
-                "id": 1,
-                "tagName": "div",
-                "childNodes": []
-            }
-        }
+        "data": {"node": {"id": 1, "tagName": "div", "childNodes": []}},
     }
-    
+
     node_by_id = init_dom_state(full_snapshot_event)
-    
+
     div_node = node_by_id[1]
     assert div_node.attributes == {}
     assert div_node.text == ""
@@ -153,22 +141,16 @@ def test_init_dom_state_empty_attributes():
 
 def test_init_dom_state_invalid_event_type():
     """Test that non-FullSnapshot events raise ValueError."""
-    invalid_event = {
-        "type": 3,  # Not a FullSnapshot
-        "data": {"source": 0}
-    }
-    
+    invalid_event = {"type": 3, "data": {"source": 0}}  # Not a FullSnapshot
+
     with pytest.raises(ValueError, match="Event must be a FullSnapshot event"):
         init_dom_state(invalid_event)
 
 
 def test_init_dom_state_missing_data_node():
     """Test that events without data.node raise ValueError."""
-    invalid_event = {
-        "type": 2,
-        "data": {}  # Missing node
-    }
-    
+    invalid_event = {"type": 2, "data": {}}  # Missing node
+
     with pytest.raises(ValueError, match="FullSnapshot event must contain data.node"):
         init_dom_state(invalid_event)
 
@@ -179,7 +161,7 @@ def test_init_dom_state_missing_data():
         "type": 2
         # Missing data entirely
     }
-    
+
     with pytest.raises(ValueError, match="FullSnapshot event must contain data.node"):
         init_dom_state(invalid_event)
 
@@ -196,25 +178,21 @@ def test_init_dom_state_nodes_without_ids_ignored():
                     {
                         # Missing id - should be ignored
                         "tagName": "span",
-                        "textContent": "No ID"
+                        "textContent": "No ID",
                     },
-                    {
-                        "id": 2,
-                        "tagName": "p",
-                        "textContent": "Has ID"
-                    }
-                ]
+                    {"id": 2, "tagName": "p", "textContent": "Has ID"},
+                ],
             }
-        }
+        },
     }
-    
+
     node_by_id = init_dom_state(full_snapshot_event)
-    
+
     # Should only contain nodes with IDs
     assert len(node_by_id) == 2
     assert 1 in node_by_id
     assert 2 in node_by_id
-    
+
     # Verify the valid child node
     p_node = node_by_id[2]
     assert p_node.tag == "p"


### PR DESCRIPTION
**What it accomplishes:**

* On receipt of a `Chunk`, consume any accompanying full-snapshot event and build the initial `node_by_id` map with node metadata.

**How to verify:**

* Unit test supplies a synthetic “full snapshot” payload and asserts that `node_by_id` contains the correct node IDs, tags, and attributes.

--
Introduces the initialization logic for a virtual DOM state from rrweb FullSnapshot events, accompanied by comprehensive tests, and updates the project TODO to reflect completion of these tasks.

* Added init_dom_state to traverse a FullSnapshot payload and build a map of UINode instances keyed by node ID.
* Created unit tests verifying correct node creation, attribute/text capture, error handling, and ignoring nodes without IDs.
* Updated todo.md checklist to mark DOM initialization steps as done.
