### PR TITLE
Create constants and utility helpers to cover the interactions with rrweb session data

### DIFF
--- a/test_gen/feature_extraction/clustering.py
+++ b/test_gen/feature_extraction/clustering.py
@@ -21,9 +21,10 @@ Usage:
 """
 
 from typing import List
+
+from rrweb_util import is_mouse_move_event, get_event_timestamp, get_mouse_coordinates
 from .models import MouseCluster
 from . import config
-from rrweb_util import is_mouse_move_event, get_event_timestamp, get_mouse_coordinates
 
 
 def cluster_mouse_trajectories(

--- a/test_gen/feature_extraction/clustering.py
+++ b/test_gen/feature_extraction/clustering.py
@@ -23,6 +23,7 @@ Usage:
 from typing import List
 from .models import MouseCluster
 from . import config
+from ..rrweb_util import is_mouse_move_event, get_event_timestamp, get_mouse_coordinates
 
 
 def cluster_mouse_trajectories(
@@ -92,11 +93,7 @@ def _filter_mousemove_events(events: List[dict]) -> List[dict]:
     Returns:
         List of events where type == 3 and data.source == 1
     """
-    return [
-        event
-        for event in events
-        if event.get("type") == 3 and event.get("data", {}).get("source") == 1
-    ]
+    return [event for event in events if is_mouse_move_event(event)]
 
 
 def _extract_point_from_event(event: dict) -> dict:
@@ -109,11 +106,8 @@ def _extract_point_from_event(event: dict) -> dict:
     Returns:
         Dictionary with x, y, and ts keys
     """
-    data = event.get("data", {})
-    timestamp = event.get("timestamp", 0)
-    x = data.get("x", 0)
-    y = data.get("y", 0)
-
+    timestamp = get_event_timestamp(event)
+    x, y = get_mouse_coordinates(event)
     return {"x": x, "y": y, "ts": timestamp}
 
 

--- a/test_gen/feature_extraction/clustering.py
+++ b/test_gen/feature_extraction/clustering.py
@@ -23,7 +23,7 @@ Usage:
 from typing import List
 from .models import MouseCluster
 from . import config
-from ..rrweb_util import is_mouse_move_event, get_event_timestamp, get_mouse_coordinates
+from rrweb_util import is_mouse_move_event, get_event_timestamp, get_mouse_coordinates
 
 
 def cluster_mouse_trajectories(

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -138,5 +138,3 @@ def _apply_text_changes(node_by_id: Dict[int, UINode], texts: List[dict]) -> Non
         if node_id is not None and node_id in node_by_id:
             new_text = text_record.get("value", "")
             node_by_id[node_id].text = new_text
-
-

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -8,8 +8,9 @@ through mutation tracking.
 """
 
 from typing import Dict, List
-from .models import UINode
+
 from rrweb_util import is_full_snapshot, is_dom_mutation_event, get_tag_name
+from .models import UINode
 
 
 def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -9,24 +9,7 @@ through mutation tracking.
 
 from typing import Dict, List
 from .models import UINode
-from ..rrweb_util import is_full_snapshot, is_dom_mutation_event
-
-# Sync w/ rrweb's NodeType enum
-# https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/rrdom/src/document.ts#L753
-TYPE_TO_TAG_MAP = {
-    0: "placeholder",  # Used for the root node, but potentially others
-    1: "element_node",
-    2: "attribute_node",
-    3: "text_node",
-    4: "cdata_section_node",
-    5: "entity_reference_node",
-    6: "entity_node",
-    7: "processing_instruction_node",
-    8: "comment_node",
-    9: "document_node",
-    10: "document_type_node",
-    11: "document_fragment_node",
-}
+from ..rrweb_util import is_full_snapshot, is_dom_mutation_event, get_tag_name
 
 
 def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:
@@ -157,10 +140,3 @@ def _apply_text_changes(node_by_id: Dict[int, UINode], texts: List[dict]) -> Non
             node_by_id[node_id].text = new_text
 
 
-def get_tag_name(node_data: dict) -> str:
-    """
-    Get the tag name for a given node data dictionary.
-    """
-    return node_data.get(
-        "tagName", TYPE_TO_TAG_MAP.get(node_data.get("type"), "unknown")
-    )

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -9,6 +9,7 @@ through mutation tracking.
 
 from typing import Dict, List
 from .models import UINode
+from ..rrweb_util import is_full_snapshot, is_dom_mutation_event
 
 # Sync w/ rrweb's NodeType enum
 # https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/rrdom/src/document.ts#L753
@@ -45,8 +46,8 @@ def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:
     Raises:
         ValueError: If the event is not a valid FullSnapshot event
     """
-    if full_snapshot_event.get("type") != 2:
-        raise ValueError("Event must be a FullSnapshot event (type == 2)")
+    if not is_full_snapshot(full_snapshot_event):
+        raise ValueError("Event must be a FullSnapshot event")
 
     if "data" not in full_snapshot_event or "node" not in full_snapshot_event["data"]:
         raise ValueError("FullSnapshot event must contain data.node")
@@ -101,7 +102,7 @@ def apply_mutations(node_by_id: Dict[int, UINode], mutation_events: List[dict]) 
     """
     for event in mutation_events:
         # Only process mutation events
-        if event.get("type") != 3 or event.get("data", {}).get("source") != 0:
+        if not is_dom_mutation_event(event):
             continue
 
         data = event.get("data", {})

--- a/test_gen/feature_extraction/dom_state.py
+++ b/test_gen/feature_extraction/dom_state.py
@@ -9,7 +9,7 @@ through mutation tracking.
 
 from typing import Dict, List
 from .models import UINode
-from ..rrweb_util import is_full_snapshot, is_dom_mutation_event, get_tag_name
+from rrweb_util import is_full_snapshot, is_dom_mutation_event, get_tag_name
 
 
 def init_dom_state(full_snapshot_event: dict) -> Dict[int, UINode]:

--- a/test_gen/feature_extraction/extractors.py
+++ b/test_gen/feature_extraction/extractors.py
@@ -10,8 +10,7 @@ Configuration:
 """
 
 from typing import List
-from .models import DomMutation, UserInteraction, EventDelay
-from . import config
+
 from rrweb_util import (
     is_incremental_snapshot,
     is_dom_mutation_event,
@@ -24,6 +23,8 @@ from rrweb_util import (
     get_mouse_coordinates,
     get_tag_name,
 )
+from .models import DomMutation, UserInteraction, EventDelay
+from . import config
 
 
 def extract_dom_mutations(events: List[dict]) -> List[DomMutation]:

--- a/test_gen/feature_extraction/extractors.py
+++ b/test_gen/feature_extraction/extractors.py
@@ -12,7 +12,6 @@ Configuration:
 from typing import List
 from .models import DomMutation, UserInteraction, EventDelay
 from . import config
-from .dom_state import get_tag_name
 from ..rrweb_util import (
     is_incremental_snapshot,
     is_dom_mutation_event,
@@ -23,6 +22,7 @@ from ..rrweb_util import (
     get_event_data,
     get_target_id,
     get_mouse_coordinates,
+    get_tag_name,
 )
 
 

--- a/test_gen/feature_extraction/extractors.py
+++ b/test_gen/feature_extraction/extractors.py
@@ -13,6 +13,17 @@ from typing import List
 from .models import DomMutation, UserInteraction, EventDelay
 from . import config
 from .dom_state import get_tag_name
+from ..rrweb_util import (
+    is_incremental_snapshot,
+    is_dom_mutation_event,
+    is_mouse_interaction_event,
+    is_input_event,
+    is_scroll_event,
+    get_event_timestamp,
+    get_event_data,
+    get_target_id,
+    get_mouse_coordinates,
+)
 
 
 def extract_dom_mutations(events: List[dict]) -> List[DomMutation]:
@@ -39,15 +50,11 @@ def extract_dom_mutations(events: List[dict]) -> List[DomMutation]:
 
     for event in events:
         # Only process mutation events
-        # TODO replace types w/ constants here and throughout
-        if event.get("type") != 3:
+        if not is_dom_mutation_event(event):
             continue
 
-        data = event.get("data", {})
-        if data.get("source") != 0:
-            continue
-
-        timestamp = event.get("timestamp", 0)
+        timestamp = get_event_timestamp(event)
+        data = get_event_data(event)
 
         # Extract different types of mutations
         mutations.extend(_extract_attribute_mutations(data, timestamp))
@@ -165,38 +172,35 @@ def extract_user_interactions(events: List[dict]) -> List[UserInteraction]:
 
     for event in events:
         # Only process IncrementalSnapshot events
-        if event.get("type") != 3:
+        if not is_incremental_snapshot(event):
             continue
 
-        data = event.get("data", {})
-        source = data.get("source")
-        timestamp = event.get("timestamp", 0)
+        timestamp = get_event_timestamp(event)
 
-        if source == 2:
+        if is_mouse_interaction_event(event):
             # Mouse interactions (click, dblclick)
-            interaction = _extract_click_interaction(data, timestamp)
+            interaction = _extract_click_interaction(event, timestamp)
             if interaction:
                 interactions.append(interaction)
-        elif source == 5:
+        elif is_input_event(event):
             # Input events (text changes, checkboxes)
-            interaction = _extract_input_interaction(data, timestamp)
+            interaction = _extract_input_interaction(event, timestamp)
             if interaction:
                 interactions.append(interaction)
-        elif source == 3:
+        elif is_scroll_event(event):
             # Scroll events
-            interaction = _extract_scroll_interaction(data, timestamp)
+            interaction = _extract_scroll_interaction(event, timestamp)
             if interaction:
                 interactions.append(interaction)
 
     return interactions
 
 
-def _extract_click_interaction(data: dict, timestamp: int) -> UserInteraction:
+def _extract_click_interaction(event: dict, timestamp: int) -> UserInteraction:
     """Extract click interaction from mouse event data."""
-    target_id = data.get("id")
+    target_id = get_target_id(event)
     if target_id is not None:
-        x = data.get("x", 0)
-        y = data.get("y", 0)
+        x, y = get_mouse_coordinates(event)
         return UserInteraction(
             action="click",
             target_id=target_id,
@@ -233,8 +237,8 @@ def compute_inter_event_delays(events: List[dict]) -> List[EventDelay]:
         current_event = events[i]
         next_event = events[i + 1]
 
-        from_ts = current_event.get("timestamp", 0)
-        to_ts = next_event.get("timestamp", 0)
+        from_ts = get_event_timestamp(current_event)
+        to_ts = get_event_timestamp(next_event)
         delta_ms = to_ts - from_ts
 
         delay = EventDelay(from_ts=from_ts, to_ts=to_ts, delta_ms=delta_ms)
@@ -275,31 +279,31 @@ def compute_reaction_delays(
     delays = []
 
     # Sort events by timestamp to ensure sequential processing
-    events.sort(key=lambda e: e.get("timestamp", 0))
+    events.sort(key=get_event_timestamp)
 
     # Separate interaction and mutation events
     interaction_events = [
         event
         for event in events
-        if event.get("type") == 3
-        and event.get("data", {}).get("source") == interaction_source
+        if is_incremental_snapshot(event)
+        and get_event_data(event).get("source") == interaction_source
     ]
     mutation_events = [
         event
         for event in events
-        if event.get("type") == 3
-        and event.get("data", {}).get("source") == mutation_source
+        if is_incremental_snapshot(event)
+        and get_event_data(event).get("source") == mutation_source
     ]
 
     # Use a pointer to track the position in mutation events
     mutation_index = 0
     for interaction in interaction_events:
-        interaction_ts = interaction.get("timestamp", 0)
+        interaction_ts = get_event_timestamp(interaction)
 
         # Find the next mutation event within the time window
         while mutation_index < len(mutation_events):
             mutation = mutation_events[mutation_index]
-            mutation_ts = mutation.get("timestamp", 0)
+            mutation_ts = get_event_timestamp(mutation)
 
             if (
                 mutation_ts > interaction_ts
@@ -318,10 +322,11 @@ def compute_reaction_delays(
     return delays
 
 
-def _extract_input_interaction(data: dict, timestamp: int) -> UserInteraction:
+def _extract_input_interaction(event: dict, timestamp: int) -> UserInteraction:
     """Extract input interaction from input event data."""
-    target_id = data.get("id")
+    target_id = get_target_id(event)
     if target_id is not None:
+        data = get_event_data(event)
         # Input events can have either 'text' or 'isChecked' fields
         value = {}
         if "text" in data:
@@ -338,10 +343,11 @@ def _extract_input_interaction(data: dict, timestamp: int) -> UserInteraction:
     return None
 
 
-def _extract_scroll_interaction(data: dict, timestamp: int) -> UserInteraction:
+def _extract_scroll_interaction(event: dict, timestamp: int) -> UserInteraction:
     """Extract scroll interaction from scroll event data."""
-    target_id = data.get("id")
+    target_id = get_target_id(event)
     if target_id is not None:
+        data = get_event_data(event)
         x = data.get("x", 0)
         y = data.get("y", 0)
         return UserInteraction(

--- a/test_gen/feature_extraction/extractors.py
+++ b/test_gen/feature_extraction/extractors.py
@@ -12,7 +12,7 @@ Configuration:
 from typing import List
 from .models import DomMutation, UserInteraction, EventDelay
 from . import config
-from ..rrweb_util import (
+from rrweb_util import (
     is_incremental_snapshot,
     is_dom_mutation_event,
     is_mouse_interaction_event,

--- a/test_gen/feature_extraction/scroll_patterns.py
+++ b/test_gen/feature_extraction/scroll_patterns.py
@@ -27,7 +27,7 @@ Usage:
 from typing import List
 from .models import ScrollPattern
 from . import config
-from ..rrweb_util import is_scroll_event, is_dom_mutation_event, get_event_timestamp
+from rrweb_util import is_scroll_event, is_dom_mutation_event, get_event_timestamp
 
 
 def detect_scroll_patterns(

--- a/test_gen/feature_extraction/scroll_patterns.py
+++ b/test_gen/feature_extraction/scroll_patterns.py
@@ -25,9 +25,10 @@ Usage:
 """
 
 from typing import List
+
+from rrweb_util import is_scroll_event, is_dom_mutation_event, get_event_timestamp
 from .models import ScrollPattern
 from . import config
-from rrweb_util import is_scroll_event, is_dom_mutation_event, get_event_timestamp
 
 
 def detect_scroll_patterns(

--- a/test_gen/feature_extraction/scroll_patterns.py
+++ b/test_gen/feature_extraction/scroll_patterns.py
@@ -27,6 +27,7 @@ Usage:
 from typing import List
 from .models import ScrollPattern
 from . import config
+from ..rrweb_util import is_scroll_event, is_dom_mutation_event, get_event_timestamp
 
 
 def detect_scroll_patterns(
@@ -69,12 +70,12 @@ def detect_scroll_patterns(
     mutation_index = 0
 
     for scroll_event in scroll_events:
-        scroll_ts = scroll_event.get("timestamp", 0)
+        scroll_ts = get_event_timestamp(scroll_event)
 
         # Look for the next mutation event within the time window
         while mutation_index < len(mutation_events):
             mutation_event = mutation_events[mutation_index]
-            mutation_ts = mutation_event.get("timestamp", 0)
+            mutation_ts = get_event_timestamp(mutation_event)
 
             # If mutation is before scroll, skip it
             if mutation_ts <= scroll_ts:
@@ -109,13 +110,9 @@ def _filter_scroll_events(events: List[dict]) -> List[dict]:
     Returns:
         List of events where type == 3 and data.source == 3, sorted by timestamp
     """
-    scroll_events = [
-        event
-        for event in events
-        if event.get("type") == 3 and event.get("data", {}).get("source") == 3
-    ]
+    scroll_events = [event for event in events if is_scroll_event(event)]
     # Sort by timestamp to ensure chronological processing
-    scroll_events.sort(key=lambda e: e.get("timestamp", 0))
+    scroll_events.sort(key=get_event_timestamp)
     return scroll_events
 
 
@@ -129,11 +126,7 @@ def _filter_mutation_events(events: List[dict]) -> List[dict]:
     Returns:
         List of events where type == 3 and data.source == 0, sorted by timestamp
     """
-    mutation_events = [
-        event
-        for event in events
-        if event.get("type") == 3 and event.get("data", {}).get("source") == 0
-    ]
+    mutation_events = [event for event in events if is_dom_mutation_event(event)]
     # Sort by timestamp to ensure chronological processing
-    mutation_events.sort(key=lambda e: e.get("timestamp", 0))
+    mutation_events.sort(key=get_event_timestamp)
     return mutation_events

--- a/test_gen/feature_extraction/tests/test_clustering.py
+++ b/test_gen/feature_extraction/tests/test_clustering.py
@@ -20,13 +20,29 @@ def fixture_non_mousemove_events():
         # FullSnapshot event
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Click event (source 2)
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1100,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},
+        },
         # DOM mutation (source 0)
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1200, "data": {"source": IncrementalSource.MUTATION, "adds": []}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1200,
+            "data": {"source": IncrementalSource.MUTATION, "adds": []},
+        },
         # Scroll event (source 3)
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1300, "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1300,
+            "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100},
+        },
         # Input event (source 5)
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1400, "data": {"source": IncrementalSource.INPUT, "text": "input"}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1400,
+            "data": {"source": IncrementalSource.INPUT, "text": "input"},
+        },
     ]
 
 

--- a/test_gen/feature_extraction/tests/test_delay_extractor.py
+++ b/test_gen/feature_extraction/tests/test_delay_extractor.py
@@ -23,7 +23,11 @@ def test_compute_inter_event_delays_preserves_order():
     events = [
         {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 100, "data": {}},
         {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 200, "data": {}},
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 150, "data": {}},  # Out of order timestamp
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 150,
+            "data": {},
+        },  # Out of order timestamp
         {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 300, "data": {}},
     ]
 
@@ -60,12 +64,24 @@ def test_compute_inter_event_delays_missing_timestamps():
 def test_compute_reaction_delays_custom_sources():
     """Test reaction delays with custom interaction and mutation sources."""
     events = [
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.INPUT, "id": 42}},  # Input event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1200, "data": {"source": IncrementalSource.MUTATION, "adds": []}},  # Mutation
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.INPUT, "id": 42},
+        },  # Input event
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1200,
+            "data": {"source": IncrementalSource.MUTATION, "adds": []},
+        },  # Mutation
     ]
 
     # Use input events (source 5) as interactions
-    delays = compute_reaction_delays(events, interaction_source=IncrementalSource.INPUT, mutation_source=IncrementalSource.MUTATION)
+    delays = compute_reaction_delays(
+        events,
+        interaction_source=IncrementalSource.INPUT,
+        mutation_source=IncrementalSource.MUTATION,
+    )
 
     assert len(delays) == 1
     delay = delays[0]
@@ -77,7 +93,11 @@ def test_compute_reaction_delays_custom_sources():
 def test_compute_reaction_delays_first_mutation_only():
     """Test that each interaction matches only the first mutation within window."""
     events = [
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},  # Click
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},
+        },  # Click
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,
@@ -103,9 +123,21 @@ def test_compute_reaction_delays_first_mutation_only():
 def test_compute_reaction_delays_no_mutations():
     """Test that interactions with no subsequent mutations produce no delays."""
     events = [
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},  # Click
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100}},  # Mouse move
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1200, "data": {"source": IncrementalSource.SCROLL, "y": 200}},  # Scroll
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},
+        },  # Click
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1100,
+            "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100},
+        },  # Mouse move
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1200,
+            "data": {"source": IncrementalSource.SCROLL, "y": 200},
+        },  # Scroll
     ]
 
     delays = compute_reaction_delays(events)
@@ -122,7 +154,11 @@ def test_compute_reaction_delays_mutation_before_interaction():
             "timestamp": 1000,
             "data": {"source": IncrementalSource.MUTATION, "adds": []},
         },  # Mutation first
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},  # Click after
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1100,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},
+        },  # Click after
     ]
 
     delays = compute_reaction_delays(events)

--- a/test_gen/feature_extraction/tests/test_dom_extractor.py
+++ b/test_gen/feature_extraction/tests/test_dom_extractor.py
@@ -39,11 +39,23 @@ def fixture_non_mutation_events():
         # FullSnapshot event
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Mouse move event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 2000,
+            "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200},
+        },
         # Click event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 3000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 123}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 3000,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 123},
+        },
         # Scroll event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 4000, "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 4000,
+            "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100},
+        },
         # Input event
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -76,7 +88,11 @@ def test_extract_empty_mutation_data():
     """Test that events with empty mutation data do not produce spurious entries."""
     empty_mutation_events = [
         # Event with no mutation data at all
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.MUTATION},
+        },
         # Event with empty mutation arrays
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -109,7 +125,10 @@ def test_extract_preserves_event_order():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 2, "value": "text"}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "texts": [{"id": 2, "value": "text"}],
+            },
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,

--- a/test_gen/feature_extraction/tests/test_dom_extractor.py
+++ b/test_gen/feature_extraction/tests/test_dom_extractor.py
@@ -7,16 +7,17 @@ covering attribute changes, text modifications, node additions, and removals.
 
 import pytest
 from feature_extraction.extractors import extract_dom_mutations
+from rrweb_util import EventType, IncrementalSource
 
 
 @pytest.fixture(name="single_attribute_mutation_event")
 def fixture_single_attribute_mutation_event():
     """Fixture providing a mutation event with multiple attribute changes."""
     return {
-        "type": 3,
+        "type": EventType.INCREMENTAL_SNAPSHOT,
         "timestamp": 12345,
         "data": {
-            "source": 0,
+            "source": IncrementalSource.MUTATION,
             "attributes": [
                 {
                     "id": 42,
@@ -36,18 +37,18 @@ def fixture_non_mutation_events():
     """Fixture providing events that are not mutation events."""
     return [
         # FullSnapshot event
-        {"type": 2, "timestamp": 1000, "data": {"node": {}}},
+        {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Mouse move event
-        {"type": 3, "timestamp": 2000, "data": {"source": 1, "x": 100, "y": 200}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200}},
         # Click event
-        {"type": 3, "timestamp": 3000, "data": {"source": 2, "id": 123}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 3000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 123}},
         # Scroll event
-        {"type": 3, "timestamp": 4000, "data": {"source": 3, "x": 0, "y": 100}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 4000, "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100}},
         # Input event
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 5000,
-            "data": {"source": 5, "id": 456, "text": "input"},
+            "data": {"source": IncrementalSource.INPUT, "id": 456, "text": "input"},
         },
     ]
 
@@ -75,13 +76,13 @@ def test_extract_empty_mutation_data():
     """Test that events with empty mutation data do not produce spurious entries."""
     empty_mutation_events = [
         # Event with no mutation data at all
-        {"type": 3, "timestamp": 1000, "data": {"source": 0}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},
         # Event with empty mutation arrays
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
             "data": {
-                "source": 0,
+                "source": IncrementalSource.MUTATION,
                 "attributes": [],
                 "texts": [],
                 "adds": [],
@@ -101,20 +102,20 @@ def test_extract_preserves_event_order():
     # Create events with different timestamps in a specific order
     events = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 0, "removes": [{"id": 1}]},
+            "data": {"source": IncrementalSource.MUTATION, "removes": [{"id": 1}]},
         },
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": 0, "texts": [{"id": 2, "value": "text"}]},
+            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 2, "value": "text"}]},
         },
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 3000,
             "data": {
-                "source": 0,
+                "source": IncrementalSource.MUTATION,
                 "attributes": [{"id": 3, "attributes": {"class": "test"}}],
             },
         },
@@ -136,10 +137,10 @@ def test_extract_handles_missing_node_ids():
     """Test that mutation records without node IDs are safely ignored."""
     events_with_missing_ids = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
             "data": {
-                "source": 0,
+                "source": IncrementalSource.MUTATION,
                 "attributes": [
                     {"attributes": {"class": "test"}},  # Missing id
                     {"id": 42, "attributes": {"valid": "true"}},  # Valid
@@ -182,16 +183,16 @@ def test_extract_handles_missing_node_ids():
 def test_extract_handles_node_type_fallback():
     """Test that node additions handle 'type' field when 'tagName' is missing."""
     event_with_type_field = {
-        "type": 3,
+        "type": EventType.INCREMENTAL_SNAPSHOT,
         "timestamp": 1000,
         "data": {
-            "source": 0,
+            "source": IncrementalSource.MUTATION,
             "adds": [
                 {
                     "parentId": 50,
                     "node": {
                         "id": 100,
-                        "type": 3,  # Using 'type' instead of 'tagName'.  Tuype for text_node
+                        "type": 3,  # Using 'type' instead of 'tagName'.  Type for text_node
                         "textContent": "Text node",
                     },
                 }

--- a/test_gen/feature_extraction/tests/test_dom_state.py
+++ b/test_gen/feature_extraction/tests/test_dom_state.py
@@ -20,7 +20,7 @@ def fixture_simple_full_snapshot():
         "data": {
             "node": {
                 "id": 1,
-                "type": 9, # "document_node",
+                "type": 9,  # "document_node",
                 "childNodes": [
                     {
                         "id": 2,
@@ -166,7 +166,10 @@ def test_init_dom_state_empty_attributes():
     "invalid_event,expected_error",
     [
         (
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "data": {"source": IncrementalSource.MUTATION}},  # Not a FullSnapshot
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "data": {"source": IncrementalSource.MUTATION},
+            },  # Not a FullSnapshot
             "Event must be a FullSnapshot event",
         ),
         (
@@ -421,7 +424,10 @@ def test_apply_mutations_mixed_operations(simple_node_by_id):
     [
         # Non-mutation events
         [
-            {"type": EventType.FULL_SNAPSHOT, "data": {"node": {}}},  # FullSnapshot, not mutation
+            {
+                "type": EventType.FULL_SNAPSHOT,
+                "data": {"node": {}},
+            },  # FullSnapshot, not mutation
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "data": {"source": IncrementalSource.MOUSE_MOVE},
@@ -433,7 +439,10 @@ def test_apply_mutations_mixed_operations(simple_node_by_id):
         ],
         # Empty mutation data
         [
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "data": {"source": IncrementalSource.MUTATION}},  # No mutation data
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "data": {"source": IncrementalSource.MUTATION},
+            },  # No mutation data
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "data": {

--- a/test_gen/feature_extraction/tests/test_interactions_extractor.py
+++ b/test_gen/feature_extraction/tests/test_interactions_extractor.py
@@ -5,6 +5,8 @@ Tests the extraction of structured UserInteraction records from rrweb events,
 covering click, input, and scroll interactions with proper field mapping.
 """
 
+# pylint: disable=duplicate-code
+
 import pytest
 from feature_extraction.extractors import extract_user_interactions
 from rrweb_util import EventType, IncrementalSource

--- a/test_gen/feature_extraction/tests/test_interactions_extractor.py
+++ b/test_gen/feature_extraction/tests/test_interactions_extractor.py
@@ -17,7 +17,11 @@ def fixture_non_interaction_events():
         # FullSnapshot event
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Mouse move event (source 1)
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 2000,
+            "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200},
+        },
         # DOM mutation event (source 0)
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -25,9 +29,17 @@ def fixture_non_interaction_events():
             "data": {"source": IncrementalSource.MUTATION, "adds": []},
         },
         # Unknown source
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 4000, "data": {"source": 99, "id": 123}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 4000,
+            "data": {"source": 99, "id": 123},
+        },
         # Meta event
-        {"type": EventType.CUSTOM, "timestamp": 5000, "data": {"width": 1920, "height": 1080}},
+        {
+            "type": EventType.CUSTOM,
+            "timestamp": 5000,
+            "data": {"width": 1920, "height": 1080},
+        },
     ]
 
 
@@ -51,7 +63,12 @@ def test_extract_preserves_event_order():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 2, "x": 50, "y": 60},
+            "data": {
+                "source": IncrementalSource.MOUSE_INTERACTION,
+                "id": 2,
+                "x": 50,
+                "y": 60,
+            },
         },  # click
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -78,12 +95,21 @@ def test_extract_handles_missing_target_ids():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "x": 100, "y": 200},  # Missing id
+            "data": {
+                "source": IncrementalSource.MOUSE_INTERACTION,
+                "x": 100,
+                "y": 200,
+            },  # Missing id
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42, "x": 150, "y": 250},  # Valid
+            "data": {
+                "source": IncrementalSource.MOUSE_INTERACTION,
+                "id": 42,
+                "x": 150,
+                "y": 250,
+            },  # Valid
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -93,17 +119,30 @@ def test_extract_handles_missing_target_ids():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 4000,
-            "data": {"source": IncrementalSource.INPUT, "id": 43, "text": "valid"},  # Valid
+            "data": {
+                "source": IncrementalSource.INPUT,
+                "id": 43,
+                "text": "valid",
+            },  # Valid
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 5000,
-            "data": {"source": IncrementalSource.SCROLL, "x": 0, "y": 100},  # Missing id
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "x": 0,
+                "y": 100,
+            },  # Missing id
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 6000,
-            "data": {"source": IncrementalSource.SCROLL, "id": 44, "x": 0, "y": 200},  # Valid
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "id": 44,
+                "x": 0,
+                "y": 200,
+            },  # Valid
         },
     ]
 
@@ -125,17 +164,28 @@ def test_extract_handles_missing_coordinates():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},  # Missing x, y
+            "data": {
+                "source": IncrementalSource.MOUSE_INTERACTION,
+                "id": 42,
+            },  # Missing x, y
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": IncrementalSource.SCROLL, "id": 43, "x": 100},  # Missing y
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "id": 43,
+                "x": 100,
+            },  # Missing y
         },
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 3000,
-            "data": {"source": IncrementalSource.SCROLL, "id": 44, "y": 200},  # Missing x
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "id": 44,
+                "y": 200,
+            },  # Missing x
         },
     ]
 
@@ -168,7 +218,10 @@ def test_extract_handles_empty_input_data():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.INPUT, "id": 42},  # No text or isChecked
+            "data": {
+                "source": IncrementalSource.INPUT,
+                "id": 42,
+            },  # No text or isChecked
         }
     ]
 

--- a/test_gen/feature_extraction/tests/test_scroll_patterns.py
+++ b/test_gen/feature_extraction/tests/test_scroll_patterns.py
@@ -23,7 +23,10 @@ def fixture_scroll_with_mutation_outside_window():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 4000,  # 3000ms later (outside 2000ms window)
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # Mutation
     ]
 
@@ -62,12 +65,18 @@ def fixture_out_of_order_events():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # Mutation (earlier timestamp)
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2200,  # 200ms after scroll
-            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "texts": [{"id": 201, "value": "text"}],
+            },
         },  # Another mutation
     ]
 
@@ -79,13 +88,29 @@ def fixture_non_scroll_mutation_events():
         # FullSnapshot event
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Mouse move event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1100,
+            "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200},
+        },
         # Click event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1200, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1200,
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42},
+        },
         # Input event
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1300, "data": {"source": IncrementalSource.INPUT, "text": "input"}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1300,
+            "data": {"source": IncrementalSource.INPUT, "text": "input"},
+        },
         # Meta event
-        {"type": EventType.CUSTOM, "timestamp": 1400, "data": {"width": 1920, "height": 1080}},
+        {
+            "type": EventType.CUSTOM,
+            "timestamp": 1400,
+            "data": {"width": 1920, "height": 1080},
+        },
     ]
 
 
@@ -147,12 +172,18 @@ def test_scroll_matches_first_mutation_only():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,  # 200ms later
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # First mutation
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1400,  # 400ms later
-            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "texts": [{"id": 201, "value": "text"}],
+            },
         },  # Second mutation
     ]
 
@@ -182,12 +213,18 @@ def test_patterns_returned_in_chronological_order():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,  # 200ms after first scroll
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # Mutation for first scroll
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2300,  # 300ms after second scroll
-            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "texts": [{"id": 201, "value": "text"}],
+            },
         },  # Mutation for second scroll
     ]
 
@@ -206,7 +243,10 @@ def test_mutation_before_scroll_ignored():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # Mutation first
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
@@ -231,7 +271,10 @@ def test_missing_timestamps_default_to_zero():
         {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
+            "data": {
+                "source": IncrementalSource.MUTATION,
+                "adds": [{"node": {"id": 200}}],
+            },
         },  # Mutation with timestamp
     ]
 

--- a/test_gen/feature_extraction/tests/test_scroll_patterns.py
+++ b/test_gen/feature_extraction/tests/test_scroll_patterns.py
@@ -8,6 +8,7 @@ specified time windows, verifying correct pattern matching and timing.
 import pytest
 
 from feature_extraction.scroll_patterns import detect_scroll_patterns
+from rrweb_util import EventType, IncrementalSource
 
 
 @pytest.fixture(name="scroll_with_mutation_outside_window")
@@ -15,14 +16,14 @@ def fixture_scroll_with_mutation_outside_window():
     """Fixture providing a scroll event with mutation outside the time window."""
     return [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 4000,  # 3000ms later (outside 2000ms window)
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # Mutation
     ]
 
@@ -32,19 +33,19 @@ def fixture_scroll_with_no_mutation():
     """Fixture providing a scroll event with no subsequent mutation."""
     return [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1500,
-            "data": {"source": 1, "x": 200, "y": 300},
+            "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 200, "y": 300},
         },  # Mouse move
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": 2, "id": 150},
+            "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 150},
         },  # Click
     ]
 
@@ -54,19 +55,19 @@ def fixture_out_of_order_events():
     """Fixture providing events with timestamps out of chronological order."""
     return [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll (later timestamp)
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # Mutation (earlier timestamp)
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2200,  # 200ms after scroll
-            "data": {"source": 0, "texts": [{"id": 201, "value": "text"}]},
+            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
         },  # Another mutation
     ]
 
@@ -76,15 +77,15 @@ def fixture_non_scroll_mutation_events():
     """Fixture providing events that are not scroll or mutation events."""
     return [
         # FullSnapshot event
-        {"type": 2, "timestamp": 1000, "data": {"node": {}}},
+        {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"node": {}}},
         # Mouse move event
-        {"type": 3, "timestamp": 1100, "data": {"source": 1, "x": 100, "y": 200}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_MOVE, "x": 100, "y": 200}},
         # Click event
-        {"type": 3, "timestamp": 1200, "data": {"source": 2, "id": 42}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1200, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 42}},
         # Input event
-        {"type": 3, "timestamp": 1300, "data": {"source": 5, "text": "input"}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1300, "data": {"source": IncrementalSource.INPUT, "text": "input"}},
         # Meta event
-        {"type": 4, "timestamp": 1400, "data": {"width": 1920, "height": 1080}},
+        {"type": EventType.CUSTOM, "timestamp": 1400, "data": {"width": 1920, "height": 1080}},
     ]
 
 
@@ -139,19 +140,19 @@ def test_scroll_matches_first_mutation_only():
     """Test that each scroll matches at most one mutation (the first within window)."""
     events = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,  # 200ms later
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # First mutation
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1400,  # 400ms later
-            "data": {"source": 0, "texts": [{"id": 201, "value": "text"}]},
+            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
         },  # Second mutation
     ]
 
@@ -169,24 +170,24 @@ def test_patterns_returned_in_chronological_order():
     """Test that ScrollPattern records are returned in chronological order by scroll timestamp."""
     events = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2000,
-            "data": {"source": 3, "id": 101, "x": 0, "y": 1000},
+            "data": {"source": IncrementalSource.SCROLL, "id": 101, "x": 0, "y": 1000},
         },  # Second scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # First scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,  # 200ms after first scroll
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # Mutation for first scroll
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 2300,  # 300ms after second scroll
-            "data": {"source": 0, "texts": [{"id": 201, "value": "text"}]},
+            "data": {"source": IncrementalSource.MUTATION, "texts": [{"id": 201, "value": "text"}]},
         },  # Mutation for second scroll
     ]
 
@@ -203,14 +204,14 @@ def test_mutation_before_scroll_ignored():
     """Test that mutations occurring before scroll events are not matched."""
     events = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # Mutation first
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1500,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll after
     ]
 
@@ -224,13 +225,13 @@ def test_missing_timestamps_default_to_zero():
     """Test that events with missing timestamps are handled gracefully."""
     events = [
         {
-            "type": 3,
-            "data": {"source": 3, "id": 100, "x": 0, "y": 500},
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "data": {"source": IncrementalSource.SCROLL, "id": 100, "x": 0, "y": 500},
         },  # Scroll with missing timestamp
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": 0, "adds": [{"node": {"id": 200}}]},
+            "data": {"source": IncrementalSource.MUTATION, "adds": [{"node": {"id": 200}}]},
         },  # Mutation with timestamp
     ]
 
@@ -246,10 +247,10 @@ def test_scroll_and_mutation_event_data_preserved():
     """Test that the original scroll and mutation event data is preserved in patterns."""
     events = [
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
             "data": {
-                "source": 3,
+                "source": IncrementalSource.SCROLL,
                 "id": 100,
                 "x": 0,
                 "y": 500,
@@ -257,10 +258,10 @@ def test_scroll_and_mutation_event_data_preserved():
             },
         },
         {
-            "type": 3,
+            "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1200,
             "data": {
-                "source": 0,
+                "source": IncrementalSource.MUTATION,
                 "adds": [{"node": {"id": 200, "tagName": "div"}}],
                 "custom_field": "mutation_data",
             },

--- a/test_gen/rrweb_ingest/classifier.py
+++ b/test_gen/rrweb_ingest/classifier.py
@@ -7,6 +7,7 @@ interactions (incremental changes), and other event types for downstream process
 """
 
 from typing import List, Tuple
+from ..rrweb_util import EventType
 
 
 def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[dict]]:
@@ -36,10 +37,10 @@ def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[di
         # Access 'type' field - will raise KeyError if missing
         event_type = event["type"]
 
-        if event_type == 2:
+        if event_type == EventType.FULL_SNAPSHOT:
             # FullSnapshot events - complete DOM captures
             snapshots.append(event)
-        elif event_type == 3:
+        elif event_type == EventType.INCREMENTAL_SNAPSHOT:
             # IncrementalSnapshot events - DOM mutations, mouse moves, inputs, etc.
             interactions.append(event)
         else:

--- a/test_gen/rrweb_ingest/classifier.py
+++ b/test_gen/rrweb_ingest/classifier.py
@@ -7,7 +7,7 @@ interactions (incremental changes), and other event types for downstream process
 """
 
 from typing import List, Tuple
-from ..rrweb_util import EventType
+from rrweb_util import EventType
 
 
 def classify_events(events: List[dict]) -> Tuple[List[dict], List[dict], List[dict]]:

--- a/test_gen/rrweb_ingest/filter.py
+++ b/test_gen/rrweb_ingest/filter.py
@@ -8,7 +8,7 @@ user interactions.
 """
 
 from typing import List, Set, Tuple
-from . import config
+
 from rrweb_util import (
     is_incremental_snapshot,
     is_mouse_move_event,
@@ -16,6 +16,7 @@ from rrweb_util import (
     is_dom_mutation_event,
     get_scroll_delta,
 )
+from . import config
 
 
 def is_low_signal(event: dict) -> bool:

--- a/test_gen/rrweb_ingest/filter.py
+++ b/test_gen/rrweb_ingest/filter.py
@@ -9,7 +9,7 @@ user interactions.
 
 from typing import List, Set, Tuple
 from . import config
-from ..rrweb_util import (
+from rrweb_util import (
     is_incremental_snapshot,
     is_mouse_move_event,
     is_scroll_event,

--- a/test_gen/rrweb_ingest/segmenter.py
+++ b/test_gen/rrweb_ingest/segmenter.py
@@ -8,6 +8,7 @@ that can be processed independently for feature extraction.
 
 from typing import List
 from . import config
+from ..rrweb_util import get_event_timestamp
 
 
 def _new_chunk(snapshot_before=None) -> dict:
@@ -74,10 +75,10 @@ def segment_into_chunks(
     last_timestamp = None
 
     for interaction in interactions:
-        interaction_timestamp = interaction["timestamp"]
+        interaction_timestamp = get_event_timestamp(interaction)
 
         # Check if we need to start a new chunk due to snapshot boundary
-        while next_snapshot and interaction_timestamp >= next_snapshot["timestamp"]:
+        while next_snapshot and interaction_timestamp >= get_event_timestamp(next_snapshot):
             # Finish current chunk if it has events
             if current_chunk["interactions"]:
                 chunks.append(current_chunk)

--- a/test_gen/rrweb_ingest/segmenter.py
+++ b/test_gen/rrweb_ingest/segmenter.py
@@ -7,8 +7,9 @@ that can be processed independently for feature extraction.
 """
 
 from typing import List
-from . import config
+
 from rrweb_util import get_event_timestamp
+from . import config
 
 
 def _new_chunk(snapshot_before=None) -> dict:

--- a/test_gen/rrweb_ingest/segmenter.py
+++ b/test_gen/rrweb_ingest/segmenter.py
@@ -8,7 +8,7 @@ that can be processed independently for feature extraction.
 
 from typing import List
 from . import config
-from ..rrweb_util import get_event_timestamp
+from rrweb_util import get_event_timestamp
 
 
 def _new_chunk(snapshot_before=None) -> dict:

--- a/test_gen/rrweb_ingest/segmenter.py
+++ b/test_gen/rrweb_ingest/segmenter.py
@@ -78,7 +78,9 @@ def segment_into_chunks(
         interaction_timestamp = get_event_timestamp(interaction)
 
         # Check if we need to start a new chunk due to snapshot boundary
-        while next_snapshot and interaction_timestamp >= get_event_timestamp(next_snapshot):
+        while next_snapshot and interaction_timestamp >= get_event_timestamp(
+            next_snapshot
+        ):
             # Finish current chunk if it has events
             if current_chunk["interactions"]:
                 chunks.append(current_chunk)

--- a/test_gen/rrweb_ingest/tests/test_classifier.py
+++ b/test_gen/rrweb_ingest/tests/test_classifier.py
@@ -7,6 +7,7 @@ into snapshots, interactions, and others based on event type.
 
 import pytest
 from rrweb_ingest.classifier import classify_events
+from rrweb_util import EventType
 
 
 def test_classify_empty_event_list():

--- a/test_gen/rrweb_ingest/tests/test_classifier.py
+++ b/test_gen/rrweb_ingest/tests/test_classifier.py
@@ -51,11 +51,11 @@ def test_classify_unexpected_type_values():
 def test_classify_preserves_event_order():
     """Test that events maintain their relative order within each category."""
     events = [
-        {"type": 2, "timestamp": 1000, "data": {"id": "snap1"}},
-        {"type": 3, "timestamp": 2000, "data": {"id": "int1"}},
-        {"type": 2, "timestamp": 3000, "data": {"id": "snap2"}},
-        {"type": 3, "timestamp": 4000, "data": {"id": "int2"}},
-        {"type": 0, "timestamp": 5000, "data": {"id": "other1"}},
+        {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"id": "snap1"}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"id": "int1"}},
+        {"type": EventType.FULL_SNAPSHOT, "timestamp": 3000, "data": {"id": "snap2"}},
+        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 4000, "data": {"id": "int2"}},
+        {"type": EventType.META, "timestamp": 5000, "data": {"id": "other1"}},
     ]
 
     snapshots, interactions, others = classify_events(events)

--- a/test_gen/rrweb_ingest/tests/test_classifier.py
+++ b/test_gen/rrweb_ingest/tests/test_classifier.py
@@ -52,9 +52,17 @@ def test_classify_preserves_event_order():
     """Test that events maintain their relative order within each category."""
     events = [
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"id": "snap1"}},
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"id": "int1"}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 2000,
+            "data": {"id": "int1"},
+        },
         {"type": EventType.FULL_SNAPSHOT, "timestamp": 3000, "data": {"id": "snap2"}},
-        {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 4000, "data": {"id": "int2"}},
+        {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 4000,
+            "data": {"id": "int2"},
+        },
         {"type": EventType.META, "timestamp": 5000, "data": {"id": "other1"}},
     ]
 

--- a/test_gen/rrweb_ingest/tests/test_filter.py
+++ b/test_gen/rrweb_ingest/tests/test_filter.py
@@ -5,6 +5,8 @@ Tests the is_low_signal and clean_chunk functions to ensure proper identificatio
 and removal of low-signal events and duplicates from rrweb chunks.
 """
 
+# pylint: disable=duplicate-code
+
 from unittest.mock import patch
 
 from rrweb_ingest.filter import is_low_signal, clean_chunk

--- a/test_gen/rrweb_ingest/tests/test_filter.py
+++ b/test_gen/rrweb_ingest/tests/test_filter.py
@@ -19,7 +19,10 @@ class TestIsLowSignal:
         mousemove_event = {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.MOUSE_MOVE, "positions": [{"x": 100, "y": 200}]},
+            "data": {
+                "source": IncrementalSource.MOUSE_MOVE,
+                "positions": [{"x": 100, "y": 200}],
+            },
         }
 
         assert is_low_signal(mousemove_event) is True
@@ -27,11 +30,19 @@ class TestIsLowSignal:
     def test_non_incremental_events_not_filtered(self):
         """Test that non-IncrementalSnapshot events are never filtered."""
         # FullSnapshot event
-        snapshot_event = {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_MOVE}}
+        snapshot_event = {
+            "type": EventType.FULL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.MOUSE_MOVE},
+        }
         assert is_low_signal(snapshot_event) is False
 
         # Meta event
-        meta_event = {"type": EventType.META, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_MOVE}}
+        meta_event = {
+            "type": EventType.META,
+            "timestamp": 1000,
+            "data": {"source": IncrementalSource.MOUSE_MOVE},
+        }
         assert is_low_signal(meta_event) is False
 
     def test_micro_scroll_below_threshold(self):
@@ -39,7 +50,11 @@ class TestIsLowSignal:
         micro_scroll_event = {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.SCROLL, "x": 5, "y": 10},  # Both below default 20px threshold
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "x": 5,
+                "y": 10,
+            },  # Both below default 20px threshold
         }
 
         assert is_low_signal(micro_scroll_event) is True
@@ -64,7 +79,11 @@ class TestIsLowSignal:
         significant_scroll_event = {
             "type": EventType.INCREMENTAL_SNAPSHOT,
             "timestamp": 1000,
-            "data": {"source": IncrementalSource.SCROLL, "x": 50, "y": 100},  # Above 20px threshold
+            "data": {
+                "source": IncrementalSource.SCROLL,
+                "x": 50,
+                "y": 100,
+            },  # Above 20px threshold
         }
 
         assert is_low_signal(significant_scroll_event) is False
@@ -213,7 +232,11 @@ class TestIsLowSignal:
 
     def test_event_missing_source_field(self):
         """Test handling of events missing the source field in data."""
-        event_no_source = {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {}}
+        event_no_source = {
+            "type": EventType.INCREMENTAL_SNAPSHOT,
+            "timestamp": 1000,
+            "data": {},
+        }
         assert is_low_signal(event_no_source) is False
 
 
@@ -228,10 +251,26 @@ class TestCleanChunk:
     def test_preserves_event_order(self):
         """Test that non-noise, unique events are preserved in original order."""
         events = [
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click 1
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1500, "data": {"source": IncrementalSource.MOUSE_MOVE}},  # mousemove (noise)
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},  # click 2
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 3000, "data": {"source": IncrementalSource.INPUT, "id": 15}},  # input
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click 1
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1500,
+                "data": {"source": IncrementalSource.MOUSE_MOVE},
+            },  # mousemove (noise)
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 2000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10},
+            },  # click 2
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 3000,
+                "data": {"source": IncrementalSource.INPUT, "id": 15},
+            },  # input
         ]
 
         result = clean_chunk(events)
@@ -245,11 +284,27 @@ class TestCleanChunk:
         """Test that deduplication uses correct signature components."""
         events = [
             # Same type, source, timestamp, but different target id - should keep both
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10},
+            },
             # Same everything including target id - should deduplicate
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 2000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 2000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },
         ]
 
         result = clean_chunk(events)
@@ -269,7 +324,11 @@ class TestCleanChunk:
                 "timestamp": 1000,
                 "data": {"source": IncrementalSource.SCROLL, "x": 50},
             },  # scroll without id
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.SCROLL, "x": 50}},  # duplicate
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.SCROLL, "x": 50},
+            },  # duplicate
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 2000,
@@ -286,8 +345,16 @@ class TestCleanChunk:
     def test_complex_filtering_scenario(self):
         """Test a complex scenario with multiple types of noise and duplicates."""
         events = [
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_MOVE}},  # mousemove (noise)
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1100,
+                "data": {"source": IncrementalSource.MOUSE_MOVE},
+            },  # mousemove (noise)
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1200,
@@ -325,14 +392,22 @@ class TestCleanChunk:
 
         # Should keep: click (deduplicated), significant scroll, input
         assert len(result) == 3
-        assert result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION  # click
-        assert result[1]["data"]["source"] == IncrementalSource.SCROLL  # significant scroll
+        assert (
+            result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION
+        )  # click
+        assert (
+            result[1]["data"]["source"] == IncrementalSource.SCROLL
+        )  # significant scroll
         assert result[2]["data"]["source"] == IncrementalSource.INPUT  # input
 
     def test_custom_filters_applied(self):
         """Test that custom filter functions are properly applied."""
         events = [
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1100,
@@ -356,13 +431,19 @@ class TestCleanChunk:
 
         # Should keep click and input, filter out source 99
         assert len(result) == 2
-        assert result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION  # click
+        assert (
+            result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION
+        )  # click
         assert result[1]["data"]["source"] == IncrementalSource.INPUT  # input
 
     def test_multiple_custom_filters(self):
         """Test that multiple custom filters work together."""
         events = [
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1100,
@@ -395,5 +476,7 @@ class TestCleanChunk:
 
         # Should keep only click and input
         assert len(result) == 2
-        assert result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION  # click
+        assert (
+            result[0]["data"]["source"] == IncrementalSource.MOUSE_INTERACTION
+        )  # click
         assert result[1]["data"]["source"] == IncrementalSource.INPUT  # input

--- a/test_gen/rrweb_ingest/tests/test_pipeline.py
+++ b/test_gen/rrweb_ingest/tests/test_pipeline.py
@@ -13,6 +13,7 @@ import pytest
 
 from rrweb_ingest.pipeline import ingest_session
 from rrweb_ingest.models import Chunk
+from rrweb_util import EventType, IncrementalSource
 
 
 @pytest.fixture(name="create_session_file")
@@ -45,24 +46,24 @@ class TestIngestSession:
         """Test ingesting a basic session with mixed event types."""
         events = [
             # FullSnapshot to establish baseline
-            {"type": 2, "timestamp": 1000, "data": {"source": 0}},
+            {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},
             # Some interactions
-            {"type": 3, "timestamp": 1100, "data": {"source": 2, "id": 5}},  # click
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
             {
-                "type": 3,
+                "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1200,
-                "data": {"source": 5, "text": "hello"},
+                "data": {"source": IncrementalSource.INPUT, "text": "hello"},
             },  # input
             {
-                "type": 3,
+                "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1300,
-                "data": {"source": 3, "x": 50, "y": 100},
+                "data": {"source": IncrementalSource.SCROLL, "x": 50, "y": 100},
             },  # scroll
             # Another snapshot
-            {"type": 2, "timestamp": 2000, "data": {"source": 0}},
+            {"type": EventType.FULL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MUTATION}},
             # More interactions
-            {"type": 3, "timestamp": 2100, "data": {"source": 2, "id": 10}},  # click
-            {"type": 3, "timestamp": 2200, "data": {"source": 2, "id": 15}},  # click
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},  # click
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2200, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 15}},  # click
         ]
 
         temp_path = create_session_file(events)
@@ -89,19 +90,19 @@ class TestIngestSession:
     def test_ingest_session_with_noise_filtering(self, create_session_file):
         """Test that noise events are properly filtered during ingestion."""
         events = [
-            {"type": 2, "timestamp": 1000, "data": {"source": 0}},  # snapshot
-            {"type": 3, "timestamp": 1100, "data": {"source": 2, "id": 5}},  # click
-            {"type": 3, "timestamp": 1150, "data": {"source": 1}},  # mousemove (noise)
+            {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},  # snapshot
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1150, "data": {"source": IncrementalSource.MOUSE_MOVE}},  # mousemove (noise)
             {
-                "type": 3,
+                "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1200,
-                "data": {"source": 3, "x": 5, "y": 5},
+                "data": {"source": IncrementalSource.SCROLL, "x": 5, "y": 5},
             },  # micro-scroll (noise)
-            {"type": 3, "timestamp": 1300, "data": {"source": 2, "id": 10}},  # click
+            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1300, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},  # click
             {
-                "type": 3,
+                "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1300,
-                "data": {"source": 2, "id": 10},
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10},
             },  # duplicate
         ]
 
@@ -114,7 +115,7 @@ class TestIngestSession:
 
         # Should only have the 2 unique click events (noise filtered, duplicate removed)
         assert chunk.metadata["num_events"] == 2
-        assert all(event["data"]["source"] == 2 for event in chunk.events)
+        assert all(event["data"]["source"] == IncrementalSource.MOUSE_INTERACTION for event in chunk.events)
 
     def test_ingest_session_chunking_by_snapshots(self, create_session_file):
         """Test that snapshots create proper chunk boundaries."""

--- a/test_gen/rrweb_ingest/tests/test_pipeline.py
+++ b/test_gen/rrweb_ingest/tests/test_pipeline.py
@@ -46,9 +46,17 @@ class TestIngestSession:
         """Test ingesting a basic session with mixed event types."""
         events = [
             # FullSnapshot to establish baseline
-            {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},
+            {
+                "type": EventType.FULL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MUTATION},
+            },
             # Some interactions
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1100,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1200,
@@ -60,10 +68,22 @@ class TestIngestSession:
                 "data": {"source": IncrementalSource.SCROLL, "x": 50, "y": 100},
             },  # scroll
             # Another snapshot
-            {"type": EventType.FULL_SNAPSHOT, "timestamp": 2000, "data": {"source": IncrementalSource.MUTATION}},
+            {
+                "type": EventType.FULL_SNAPSHOT,
+                "timestamp": 2000,
+                "data": {"source": IncrementalSource.MUTATION},
+            },
             # More interactions
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},  # click
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 2200, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 15}},  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 2100,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10},
+            },  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 2200,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 15},
+            },  # click
         ]
 
         temp_path = create_session_file(events)
@@ -90,15 +110,31 @@ class TestIngestSession:
     def test_ingest_session_with_noise_filtering(self, create_session_file):
         """Test that noise events are properly filtered during ingestion."""
         events = [
-            {"type": EventType.FULL_SNAPSHOT, "timestamp": 1000, "data": {"source": IncrementalSource.MUTATION}},  # snapshot
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1100, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5}},  # click
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1150, "data": {"source": IncrementalSource.MOUSE_MOVE}},  # mousemove (noise)
+            {
+                "type": EventType.FULL_SNAPSHOT,
+                "timestamp": 1000,
+                "data": {"source": IncrementalSource.MUTATION},
+            },  # snapshot
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1100,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 5},
+            },  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1150,
+                "data": {"source": IncrementalSource.MOUSE_MOVE},
+            },  # mousemove (noise)
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1200,
                 "data": {"source": IncrementalSource.SCROLL, "x": 5, "y": 5},
             },  # micro-scroll (noise)
-            {"type": EventType.INCREMENTAL_SNAPSHOT, "timestamp": 1300, "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10}},  # click
+            {
+                "type": EventType.INCREMENTAL_SNAPSHOT,
+                "timestamp": 1300,
+                "data": {"source": IncrementalSource.MOUSE_INTERACTION, "id": 10},
+            },  # click
             {
                 "type": EventType.INCREMENTAL_SNAPSHOT,
                 "timestamp": 1300,
@@ -115,7 +151,10 @@ class TestIngestSession:
 
         # Should only have the 2 unique click events (noise filtered, duplicate removed)
         assert chunk.metadata["num_events"] == 2
-        assert all(event["data"]["source"] == IncrementalSource.MOUSE_INTERACTION for event in chunk.events)
+        assert all(
+            event["data"]["source"] == IncrementalSource.MOUSE_INTERACTION
+            for event in chunk.events
+        )
 
     def test_ingest_session_chunking_by_snapshots(self, create_session_file):
         """Test that snapshots create proper chunk boundaries."""

--- a/test_gen/rrweb_util/__init__.py
+++ b/test_gen/rrweb_util/__init__.py
@@ -1,0 +1,46 @@
+"""
+Shared utilities for rrweb event processing.
+"""
+
+from .constants import EventType, IncrementalSource, MouseInteractionType, NodeType
+from .helpers import (
+    is_full_snapshot,
+    is_incremental_snapshot,
+    get_incremental_source,
+    is_mouse_move_event,
+    is_mouse_interaction_event,
+    is_scroll_event,
+    is_input_event,
+    is_dom_mutation_event,
+    get_event_timestamp,
+    get_event_data,
+    get_target_id,
+    get_mouse_coordinates,
+    get_scroll_delta,
+    get_tag_name,
+    extract_interaction_details,
+)
+
+__all__ = [
+    # Constants
+    "EventType",
+    "IncrementalSource", 
+    "MouseInteractionType",
+    "NodeType",
+    # Helpers
+    "is_full_snapshot",
+    "is_incremental_snapshot",
+    "get_incremental_source",
+    "is_mouse_move_event",
+    "is_mouse_interaction_event",
+    "is_scroll_event",
+    "is_input_event",
+    "is_dom_mutation_event",
+    "get_event_timestamp",
+    "get_event_data",
+    "get_target_id",
+    "get_mouse_coordinates",
+    "get_scroll_delta",
+    "get_tag_name",
+    "extract_interaction_details",
+]

--- a/test_gen/rrweb_util/__init__.py
+++ b/test_gen/rrweb_util/__init__.py
@@ -24,7 +24,7 @@ from .helpers import (
 __all__ = [
     # Constants
     "EventType",
-    "IncrementalSource", 
+    "IncrementalSource",
     "MouseInteractionType",
     "NodeType",
     # Helpers

--- a/test_gen/rrweb_util/constants.py
+++ b/test_gen/rrweb_util/constants.py
@@ -8,16 +8,22 @@ Shared constants for rrweb event processing across all modules.
 class EventType:
     """rrweb event type constants."""
 
-    META = 0
+    # sync w/
+    # https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/types/src/index.ts
+    DOM_CONTENT_LOADED = 0
+    LOAD = 1
     FULL_SNAPSHOT = 2
     INCREMENTAL_SNAPSHOT = 3
-    CUSTOM = 4
-    PLUGIN = 5
+    META = 4
+    CUSTOM = 5
+    PLUGIN = 6
 
 
 class IncrementalSource:
     """rrweb incremental snapshot source constants."""
 
+    # sync w/
+    # https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/types/src/index.ts#L62
     MUTATION = 0
     MOUSE_MOVE = 1
     MOUSE_INTERACTION = 2
@@ -32,11 +38,16 @@ class IncrementalSource:
     LOG = 11
     DRAG = 12
     STYLE_DECLARATION = 13
+    SELECTION = 14
+    ADOPTED_STYLE_SHEET = 15
+    CUSTOM_ELEMENT = 16
 
 
 class MouseInteractionType:
     """Mouse interaction type constants."""
 
+    # sync w/
+    # https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/types/src/index.ts#L359
     MOUSE_UP = 0
     MOUSE_DOWN = 1
     CLICK = 2
@@ -53,6 +64,8 @@ class MouseInteractionType:
 class NodeType:
     """DOM node type constants (sync with rrweb's NodeType enum)."""
 
+    # sync w/
+    # https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/rrdom/src/document.ts#L753
     PLACEHOLDER = 0
     ELEMENT_NODE = 1
     ATTRIBUTE_NODE = 2

--- a/test_gen/rrweb_util/constants.py
+++ b/test_gen/rrweb_util/constants.py
@@ -1,0 +1,73 @@
+"""
+Shared constants for rrweb event processing across all modules.
+"""
+
+class EventType:
+    """rrweb event type constants."""
+    META = 0
+    FULL_SNAPSHOT = 2
+    INCREMENTAL_SNAPSHOT = 3
+    CUSTOM = 4
+    PLUGIN = 5
+
+class IncrementalSource:
+    """rrweb incremental snapshot source constants."""
+    MUTATION = 0
+    MOUSE_MOVE = 1
+    MOUSE_INTERACTION = 2
+    SCROLL = 3
+    VIEWPORT_RESIZE = 4
+    INPUT = 5
+    TOUCH_MOVE = 6
+    MEDIA_INTERACTION = 7
+    STYLE_SHEET_RULE = 8
+    CANVAS_MUTATION = 9
+    FONT = 10
+    LOG = 11
+    DRAG = 12
+    STYLE_DECLARATION = 13
+
+class MouseInteractionType:
+    """Mouse interaction type constants."""
+    MOUSE_UP = 0
+    MOUSE_DOWN = 1
+    CLICK = 2
+    CONTEXT_MENU = 3
+    DBL_CLICK = 4
+    FOCUS = 5
+    BLUR = 6
+    TOUCH_START = 7
+    TOUCH_MOVE_DEPARTED = 8
+    TOUCH_END = 9
+    TOUCH_CANCEL = 10
+
+class NodeType:
+    """DOM node type constants (sync with rrweb's NodeType enum)."""
+    PLACEHOLDER = 0
+    ELEMENT_NODE = 1
+    ATTRIBUTE_NODE = 2
+    TEXT_NODE = 3
+    CDATA_SECTION_NODE = 4
+    ENTITY_REFERENCE_NODE = 5
+    ENTITY_NODE = 6
+    PROCESSING_INSTRUCTION_NODE = 7
+    COMMENT_NODE = 8
+    DOCUMENT_NODE = 9
+    DOCUMENT_TYPE_NODE = 10
+    DOCUMENT_FRAGMENT_NODE = 11
+
+# Node type to tag name mapping
+NODE_TYPE_TO_TAG_MAP = {
+    NodeType.PLACEHOLDER: "placeholder",
+    NodeType.ELEMENT_NODE: "element_node",
+    NodeType.ATTRIBUTE_NODE: "attribute_node",
+    NodeType.TEXT_NODE: "text_node",
+    NodeType.CDATA_SECTION_NODE: "cdata_section_node",
+    NodeType.ENTITY_REFERENCE_NODE: "entity_reference_node",
+    NodeType.ENTITY_NODE: "entity_node",
+    NodeType.PROCESSING_INSTRUCTION_NODE: "processing_instruction_node",
+    NodeType.COMMENT_NODE: "comment_node",
+    NodeType.DOCUMENT_NODE: "document_node",
+    NodeType.DOCUMENT_TYPE_NODE: "document_type_node",
+    NodeType.DOCUMENT_FRAGMENT_NODE: "document_fragment_node",
+}

--- a/test_gen/rrweb_util/constants.py
+++ b/test_gen/rrweb_util/constants.py
@@ -2,6 +2,8 @@
 Shared constants for rrweb event processing across all modules.
 """
 
+# pylint: disable=too-few-public-methods
+
 
 class EventType:
     """rrweb event type constants."""

--- a/test_gen/rrweb_util/constants.py
+++ b/test_gen/rrweb_util/constants.py
@@ -2,16 +2,20 @@
 Shared constants for rrweb event processing across all modules.
 """
 
+
 class EventType:
     """rrweb event type constants."""
+
     META = 0
     FULL_SNAPSHOT = 2
     INCREMENTAL_SNAPSHOT = 3
     CUSTOM = 4
     PLUGIN = 5
 
+
 class IncrementalSource:
     """rrweb incremental snapshot source constants."""
+
     MUTATION = 0
     MOUSE_MOVE = 1
     MOUSE_INTERACTION = 2
@@ -27,8 +31,10 @@ class IncrementalSource:
     DRAG = 12
     STYLE_DECLARATION = 13
 
+
 class MouseInteractionType:
     """Mouse interaction type constants."""
+
     MOUSE_UP = 0
     MOUSE_DOWN = 1
     CLICK = 2
@@ -41,8 +47,10 @@ class MouseInteractionType:
     TOUCH_END = 9
     TOUCH_CANCEL = 10
 
+
 class NodeType:
     """DOM node type constants (sync with rrweb's NodeType enum)."""
+
     PLACEHOLDER = 0
     ELEMENT_NODE = 1
     ATTRIBUTE_NODE = 2
@@ -55,6 +63,7 @@ class NodeType:
     DOCUMENT_NODE = 9
     DOCUMENT_TYPE_NODE = 10
     DOCUMENT_FRAGMENT_NODE = 11
+
 
 # Node type to tag name mapping
 NODE_TYPE_TO_TAG_MAP = {

--- a/test_gen/rrweb_util/helpers.py
+++ b/test_gen/rrweb_util/helpers.py
@@ -1,0 +1,94 @@
+"""
+Shared utility functions for rrweb event processing across all modules.
+"""
+
+from typing import Optional, Dict, Any, Tuple
+from .constants import EventType, IncrementalSource, NODE_TYPE_TO_TAG_MAP
+
+# Event type checking
+def is_full_snapshot(event: Dict[str, Any]) -> bool:
+    """Check if event is a FullSnapshot."""
+    return event.get("type") == EventType.FULL_SNAPSHOT
+
+def is_incremental_snapshot(event: Dict[str, Any]) -> bool:
+    """Check if event is an IncrementalSnapshot."""
+    return event.get("type") == EventType.INCREMENTAL_SNAPSHOT
+
+def get_incremental_source(event: Dict[str, Any]) -> Optional[int]:
+    """Get the source type from an incremental snapshot event."""
+    if not is_incremental_snapshot(event):
+        return None
+    return event.get("data", {}).get("source")
+
+# Specific event type checking
+def is_mouse_move_event(event: Dict[str, Any]) -> bool:
+    """Check if event is a mouse move."""
+    return get_incremental_source(event) == IncrementalSource.MOUSE_MOVE
+
+def is_mouse_interaction_event(event: Dict[str, Any]) -> bool:
+    """Check if event is a mouse click/interaction."""
+    return get_incremental_source(event) == IncrementalSource.MOUSE_INTERACTION
+
+def is_scroll_event(event: Dict[str, Any]) -> bool:
+    """Check if event is a scroll."""
+    return get_incremental_source(event) == IncrementalSource.SCROLL
+
+def is_input_event(event: Dict[str, Any]) -> bool:
+    """Check if event is an input."""
+    return get_incremental_source(event) == IncrementalSource.INPUT
+
+def is_dom_mutation_event(event: Dict[str, Any]) -> bool:
+    """Check if event is a DOM mutation."""
+    return get_incremental_source(event) == IncrementalSource.MUTATION
+
+# Data extraction helpers
+def get_event_timestamp(event: Dict[str, Any]) -> int:
+    """Safely get timestamp from event."""
+    return event.get("timestamp", 0)
+
+def get_event_data(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Safely get data from event."""
+    return event.get("data", {})
+
+def get_target_id(event: Dict[str, Any]) -> Optional[int]:
+    """Get target element ID from interaction event."""
+    return get_event_data(event).get("id")
+
+def get_mouse_coordinates(event: Dict[str, Any]) -> Tuple[int, int]:
+    """Get x, y coordinates from mouse event."""
+    data = get_event_data(event)
+    return data.get("x", 0), data.get("y", 0)
+
+def get_scroll_delta(event: Dict[str, Any]) -> Tuple[int, int]:
+    """Get x, y scroll deltas from scroll event."""
+    data = get_event_data(event)
+    return data.get("x", 0), data.get("y", 0)
+
+# DOM node helpers
+def get_tag_name(node_data: Dict[str, Any]) -> str:
+    """Get the tag name for a given node data dictionary."""
+    return node_data.get(
+        "tagName", 
+        NODE_TYPE_TO_TAG_MAP.get(node_data.get("type"), "unknown")
+    )
+
+def extract_interaction_details(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract common interaction details from event."""
+    data = get_event_data(event)
+    details = {}
+    
+    # Mouse coordinates
+    if "x" in data and "y" in data:
+        details["coordinates"] = {"x": data["x"], "y": data["y"]}
+    
+    # Input values
+    if "text" in data:
+        details["text"] = data["text"]
+    if "isChecked" in data:
+        details["checked"] = data["isChecked"]
+    
+    # Target information
+    if "id" in data:
+        details["target_id"] = data["id"]
+    
+    return details

--- a/test_gen/rrweb_util/helpers.py
+++ b/test_gen/rrweb_util/helpers.py
@@ -5,14 +5,17 @@ Shared utility functions for rrweb event processing across all modules.
 from typing import Optional, Dict, Any, Tuple
 from .constants import EventType, IncrementalSource, NODE_TYPE_TO_TAG_MAP
 
+
 # Event type checking
 def is_full_snapshot(event: Dict[str, Any]) -> bool:
     """Check if event is a FullSnapshot."""
     return event.get("type") == EventType.FULL_SNAPSHOT
 
+
 def is_incremental_snapshot(event: Dict[str, Any]) -> bool:
     """Check if event is an IncrementalSnapshot."""
     return event.get("type") == EventType.INCREMENTAL_SNAPSHOT
+
 
 def get_incremental_source(event: Dict[str, Any]) -> Optional[int]:
     """Get the source type from an incremental snapshot event."""
@@ -20,75 +23,86 @@ def get_incremental_source(event: Dict[str, Any]) -> Optional[int]:
         return None
     return event.get("data", {}).get("source")
 
+
 # Specific event type checking
 def is_mouse_move_event(event: Dict[str, Any]) -> bool:
     """Check if event is a mouse move."""
     return get_incremental_source(event) == IncrementalSource.MOUSE_MOVE
 
+
 def is_mouse_interaction_event(event: Dict[str, Any]) -> bool:
     """Check if event is a mouse click/interaction."""
     return get_incremental_source(event) == IncrementalSource.MOUSE_INTERACTION
+
 
 def is_scroll_event(event: Dict[str, Any]) -> bool:
     """Check if event is a scroll."""
     return get_incremental_source(event) == IncrementalSource.SCROLL
 
+
 def is_input_event(event: Dict[str, Any]) -> bool:
     """Check if event is an input."""
     return get_incremental_source(event) == IncrementalSource.INPUT
 
+
 def is_dom_mutation_event(event: Dict[str, Any]) -> bool:
     """Check if event is a DOM mutation."""
     return get_incremental_source(event) == IncrementalSource.MUTATION
+
 
 # Data extraction helpers
 def get_event_timestamp(event: Dict[str, Any]) -> int:
     """Safely get timestamp from event."""
     return event.get("timestamp", 0)
 
+
 def get_event_data(event: Dict[str, Any]) -> Dict[str, Any]:
     """Safely get data from event."""
     return event.get("data", {})
 
+
 def get_target_id(event: Dict[str, Any]) -> Optional[int]:
     """Get target element ID from interaction event."""
     return get_event_data(event).get("id")
+
 
 def get_mouse_coordinates(event: Dict[str, Any]) -> Tuple[int, int]:
     """Get x, y coordinates from mouse event."""
     data = get_event_data(event)
     return data.get("x", 0), data.get("y", 0)
 
+
 def get_scroll_delta(event: Dict[str, Any]) -> Tuple[int, int]:
     """Get x, y scroll deltas from scroll event."""
     data = get_event_data(event)
     return data.get("x", 0), data.get("y", 0)
 
+
 # DOM node helpers
 def get_tag_name(node_data: Dict[str, Any]) -> str:
     """Get the tag name for a given node data dictionary."""
     return node_data.get(
-        "tagName", 
-        NODE_TYPE_TO_TAG_MAP.get(node_data.get("type"), "unknown")
+        "tagName", NODE_TYPE_TO_TAG_MAP.get(node_data.get("type"), "unknown")
     )
+
 
 def extract_interaction_details(event: Dict[str, Any]) -> Dict[str, Any]:
     """Extract common interaction details from event."""
     data = get_event_data(event)
     details = {}
-    
+
     # Mouse coordinates
     if "x" in data and "y" in data:
         details["coordinates"] = {"x": data["x"], "y": data["y"]}
-    
+
     # Input values
     if "text" in data:
         details["text"] = data["text"]
     if "isChecked" in data:
         details["checked"] = data["isChecked"]
-    
+
     # Target information
     if "id" in data:
         details["target_id"] = data["id"]
-    
+
     return details


### PR DESCRIPTION
- Eliminates Magic Numbers: All hardcoded event types and sources become named constants
- Improves Readability: is_mouse_move_event(event) vs event.get("type") == 3 and event.get("data", {}).get("source") == 1
- Reduces Duplication: Common patterns like timestamp extraction are centralized
- Type Safety: Helper functions provide consistent interfaces
- Maintainability: Changes to rrweb format only require updating utilities
- Documentation: Constants serve as documentation of rrweb's structure
- Testing: Easier to create test fixtures with named constants

--
- Creates constants for all rrweb event types, sources, and node types to replace magic numbers
- Implements helper functions for common operations like event type checking and data extraction
- Updates all existing code to use the new utilities instead of hardcoded values
