### PR TITLE
Implement Rule Loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,4 +116,4 @@ update-repomix:
 
 .PHONY: implement-step
 implement-step:
-	claude "/project:implement_step \"$$(python helpers/prompt/pull_prompt.py)\""
+	claude "/project:implement_step \"$$(python helpers/prompt/pull_prompt.py $(STEP_NUMBER))\""

--- a/helpers/prompt/pull_prompt.py
+++ b/helpers/prompt/pull_prompt.py
@@ -2,8 +2,14 @@
 Utility python script which can extract a specific prompt from the prompt_plan.md markdown file.
 This is handy for passing a specific prompt to the LLM for executing on implementation steps.
 """
+import sys
 
-PROMPT_NUMBER = "1"
+if len(sys.argv) != 2:
+    print("Usage: python pull_prompt.py <step_number>")
+    print("Example: python pull_prompt.py 1")
+    sys.exit(1)
+
+PROMPT_NUMBER = sys.argv[1]
 PROMPT_DIR = "test_gen/docs/rules_based_action_matching"
 
 print(f"- Directory of with `spec.md` and `prompt_plan.md`: \"{PROMPT_DIR}\"")

--- a/test_gen/docs/rules_based_action_matching/prompt_plan.md
+++ b/test_gen/docs/rules_based_action_matching/prompt_plan.md
@@ -15,13 +15,13 @@ Introduce `DetectedAction` and `Rule` models using Python dataclasses. These rep
 
 **Detailed Prompt**
 
-### ✅ Requirements
+#### ✅ Requirements
 
 Create the following dataclasses in a new file:
 
 📄 `test_gen/rule_engine/models.py`
 
-#### 1. `DetectedAction`
+##### 1. `DetectedAction`
 
 Represents a user action detected by a rule.
 
@@ -35,7 +35,7 @@ Fields:
 * `target_element: Optional[UINode]` — the `UINode` involved, if any
 * `related_events: List[int]` — indices of events in the chunk that contributed to the match
 
-#### 2. `Rule`
+##### 2. `Rule`
 
 Represents a rule parsed from YAML.
 
@@ -52,7 +52,7 @@ Use Python 3.9+ typing (`list`, `dict`, `Optional`, not `List`, `Dict` from `typ
 
 ---
 
-### 🧪 Testing
+#### 🧪 Testing
 
 Create a unit test file:
 📄 `test_gen/rule_engine/tests/test_models.py`
@@ -77,6 +77,91 @@ Add support for loading YAML rule files from disk and converting them into `Rule
 * Load all rules in `test_gen/data/rules/` directory
 * Unit tests verify parsing of well-formed rule files
 * Invalid or missing fields raise clean validation errors
+
+**Detailed Prompt**
+
+You are building a rule-based engine that processes rrweb session chunks to detect user actions. Your current task is to implement the **Rule Loader**, which loads and validates rules from disk.
+
+---
+
+#### ✅ Requirements
+
+Create the following module:
+📄 `test_gen/rule_engine/rules_loader.py`
+
+Implement a function:
+
+```python
+def load_rules(directory: Union[str, Path]) -> List[Rule]:
+    ...
+```
+
+Where:
+
+* `directory` points to the folder containing rule files (YAML format)
+* Each file contains one rule (schema described below)
+* The function loads and parses all rule files into `Rule` objects defined in `models.py`
+
+Raise a `ValueError` for any rule missing required fields.
+
+Use the `Rule` dataclass from:
+📄 `test_gen/rule_engine/models.py`
+
+---
+
+#### 📁 Input Folder
+
+All rule files are in:
+`test_gen/data/rules/`
+Each rule is a `.yaml` file with the following structure:
+
+```yaml
+id: search_input_basic
+description: "Detects a user typing into a search box"
+match:
+  event:
+    action: input
+  node:
+    tag: input
+    attributes:
+      type: search
+confidence: 0.8
+variables:
+  input_value: event.value
+  placeholder: node.attributes.placeholder
+action_id: search_query
+```
+
+Required fields:
+
+* `id`, `match`, `confidence`, `variables`, `action_id`
+
+---
+
+#### 🧪 Testing
+
+Create the following test file:
+📄 `test_gen/rule_engine/tests/test_rules_loader.py`
+
+Write unit tests that:
+
+* Load one or more valid `.yaml` files from a temp dir or fixture
+* Confirm that a `Rule` object is returned with expected fields
+* Include negative test: malformed rule (e.g., missing `action_id`) raises `ValueError`
+* Include test for multiple rule files in the directory
+
+---
+
+#### ✅ Deliverables
+
+* `rules_loader.py` with `load_rules(...)` function
+* `test_rules_loader.py` with coverage of:
+
+  * Valid parsing
+  * Invalid structure
+  * File iteration
+
+Do not implement rule evaluation or matching yet — only loading and validation.
 
 ---
 

--- a/test_gen/requirements.txt
+++ b/test_gen/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-storage==3.1.0
+PyYAML==6.0.2

--- a/test_gen/rule_engine/rules_loader.py
+++ b/test_gen/rule_engine/rules_loader.py
@@ -1,0 +1,111 @@
+"""
+Rule loader module for loading YAML rule files from disk.
+
+This module provides functionality to load and validate rules from YAML files,
+converting them into Rule objects for use in the rule-based action detection system.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Union, Dict, Any
+
+import yaml
+
+from .models import Rule
+
+
+def load_rules(directory: Union[str, Path]) -> List[Rule]:
+    """
+    Load and validate rules from YAML files in the specified directory.
+    
+    Args:
+        directory: Path to the directory containing rule YAML files
+        
+    Returns:
+        List of Rule objects parsed from the YAML files
+        
+    Raises:
+        ValueError: If any rule is missing required fields or has invalid structure
+        FileNotFoundError: If the directory doesn't exist
+        yaml.YAMLError: If YAML files are malformed
+    """
+    directory_path = Path(directory)
+    
+    if not directory_path.exists():
+        raise FileNotFoundError(f"Rules directory does not exist: {directory}")
+    
+    if not directory_path.is_dir():
+        raise ValueError(f"Path is not a directory: {directory}")
+    
+    rules = []
+    yaml_files = list(directory_path.glob("*.yaml")) + list(directory_path.glob("*.yml"))
+    
+    for yaml_file in yaml_files:
+        try:
+            with open(yaml_file, 'r', encoding='utf-8') as file:
+                rule_data = yaml.safe_load(file)
+                
+            if rule_data is None:
+                continue  # Skip empty files
+                
+            rule = _parse_rule(rule_data, yaml_file.name)
+            rules.append(rule)
+            
+        except yaml.YAMLError as e:
+            raise yaml.YAMLError(f"Error parsing YAML file {yaml_file.name}: {e}")
+        except Exception as e:
+            raise ValueError(f"Error processing rule file {yaml_file.name}: {e}")
+    
+    return rules
+
+
+def _parse_rule(rule_data: Dict[str, Any], filename: str) -> Rule:
+    """
+    Parse rule data from YAML into a Rule object.
+    
+    Args:
+        rule_data: Dictionary containing rule data from YAML
+        filename: Name of the file being parsed (for error messages)
+        
+    Returns:
+        Rule object
+        
+    Raises:
+        ValueError: If required fields are missing or invalid
+    """
+    required_fields = ['id', 'match', 'confidence', 'variables', 'action_id']
+    
+    # Check for required fields
+    missing_fields = [field for field in required_fields if field not in rule_data]
+    if missing_fields:
+        raise ValueError(f"Rule in {filename} missing required fields: {missing_fields}")
+    
+    # Validate field types
+    if not isinstance(rule_data['id'], str):
+        raise ValueError(f"Rule in {filename}: 'id' must be a string")
+    
+    if not isinstance(rule_data['match'], dict):
+        raise ValueError(f"Rule in {filename}: 'match' must be a dictionary")
+    
+    if not isinstance(rule_data['confidence'], (int, float)) or not (0 <= rule_data['confidence'] <= 1):
+        raise ValueError(f"Rule in {filename}: 'confidence' must be a number between 0 and 1")
+    
+    if not isinstance(rule_data['variables'], dict):
+        raise ValueError(f"Rule in {filename}: 'variables' must be a dictionary")
+    
+    if not isinstance(rule_data['action_id'], str):
+        raise ValueError(f"Rule in {filename}: 'action_id' must be a string")
+    
+    # Optional description field
+    description = rule_data.get('description')
+    if description is not None and not isinstance(description, str):
+        raise ValueError(f"Rule in {filename}: 'description' must be a string")
+    
+    return Rule(
+        id=rule_data['id'],
+        description=description,
+        match=rule_data['match'],
+        confidence=float(rule_data['confidence']),
+        variables=rule_data['variables'],
+        action_id=rule_data['action_id']
+    )

--- a/test_gen/rule_engine/rules_loader.py
+++ b/test_gen/rule_engine/rules_loader.py
@@ -17,95 +17,103 @@ from .models import Rule
 def load_rules(directory: Union[str, Path]) -> List[Rule]:
     """
     Load and validate rules from YAML files in the specified directory.
-    
+
     Args:
         directory: Path to the directory containing rule YAML files
-        
+
     Returns:
         List of Rule objects parsed from the YAML files
-        
+
     Raises:
         ValueError: If any rule is missing required fields or has invalid structure
         FileNotFoundError: If the directory doesn't exist
         yaml.YAMLError: If YAML files are malformed
     """
     directory_path = Path(directory)
-    
+
     if not directory_path.exists():
         raise FileNotFoundError(f"Rules directory does not exist: {directory}")
-    
+
     if not directory_path.is_dir():
         raise ValueError(f"Path is not a directory: {directory}")
-    
+
     rules = []
-    yaml_files = list(directory_path.glob("*.yaml")) + list(directory_path.glob("*.yml"))
-    
+    yaml_files = list(directory_path.glob("*.yaml")) + list(
+        directory_path.glob("*.yml")
+    )
+
     for yaml_file in yaml_files:
         try:
-            with open(yaml_file, 'r', encoding='utf-8') as file:
+            with open(yaml_file, "r", encoding="utf-8") as file:
                 rule_data = yaml.safe_load(file)
-                
+
             if rule_data is None:
                 continue  # Skip empty files
-                
+
             rule = _parse_rule(rule_data, yaml_file.name)
             rules.append(rule)
-            
+
         except yaml.YAMLError as e:
             raise yaml.YAMLError(f"Error parsing YAML file {yaml_file.name}: {e}")
         except Exception as e:
             raise ValueError(f"Error processing rule file {yaml_file.name}: {e}")
-    
+
     return rules
 
 
 def _parse_rule(rule_data: Dict[str, Any], filename: str) -> Rule:
     """
     Parse rule data from YAML into a Rule object.
-    
+
     Args:
         rule_data: Dictionary containing rule data from YAML
         filename: Name of the file being parsed (for error messages)
-        
+
     Returns:
         Rule object
-        
+
     Raises:
         ValueError: If required fields are missing or invalid
     """
-    required_fields = ['id', 'match', 'confidence', 'variables', 'action_id']
-    
+    required_fields = ["id", "match", "confidence", "variables", "action_id"]
+
     # Check for required fields
     missing_fields = [field for field in required_fields if field not in rule_data]
     if missing_fields:
-        raise ValueError(f"Rule in {filename} missing required fields: {missing_fields}")
-    
+        raise ValueError(
+            f"Rule in {filename} missing required fields: {missing_fields}"
+        )
+
     # Validate field types
-    if not isinstance(rule_data['id'], str):
+    if not isinstance(rule_data["id"], str):
         raise ValueError(f"Rule in {filename}: 'id' must be a string")
-    
-    if not isinstance(rule_data['match'], dict):
+
+    if not isinstance(rule_data["match"], dict):
         raise ValueError(f"Rule in {filename}: 'match' must be a dictionary")
-    
-    if not isinstance(rule_data['confidence'], (int, float)) or not (0 <= rule_data['confidence'] <= 1):
-        raise ValueError(f"Rule in {filename}: 'confidence' must be a number between 0 and 1")
-    
-    if not isinstance(rule_data['variables'], dict):
+
+    if not isinstance(rule_data["confidence"], (int, float)) or not (
+        0 <= rule_data["confidence"] <= 1
+    ):
+        raise ValueError(
+            f"Rule in {filename}: 'confidence' must be a number between 0 and 1"
+        )
+
+    if not isinstance(rule_data["variables"], dict):
         raise ValueError(f"Rule in {filename}: 'variables' must be a dictionary")
-    
-    if not isinstance(rule_data['action_id'], str):
+
+    if not isinstance(rule_data["action_id"], str):
         raise ValueError(f"Rule in {filename}: 'action_id' must be a string")
-    
+
     # Optional description field
-    description = rule_data.get('description')
+    description = rule_data.get("description")
     if description is not None and not isinstance(description, str):
         raise ValueError(f"Rule in {filename}: 'description' must be a string")
-    
+
     return Rule(
-        id=rule_data['id'],
+        id=rule_data["id"],
         description=description,
-        match=rule_data['match'],
-        confidence=float(rule_data['confidence']),
-        variables=rule_data['variables'],
-        action_id=rule_data['action_id']
+        match=rule_data["match"],
+        confidence=float(rule_data["confidence"]),
+        variables=rule_data["variables"],
+        action_id=rule_data["action_id"],
     )

--- a/test_gen/rule_engine/rules_loader.py
+++ b/test_gen/rule_engine/rules_loader.py
@@ -5,7 +5,6 @@ This module provides functionality to load and validate rules from YAML files,
 converting them into Rule objects for use in the rule-based action detection system.
 """
 
-import os
 from pathlib import Path
 from typing import List, Union, Dict, Any
 
@@ -54,9 +53,11 @@ def load_rules(directory: Union[str, Path]) -> List[Rule]:
             rules.append(rule)
 
         except yaml.YAMLError as e:
-            raise yaml.YAMLError(f"Error parsing YAML file {yaml_file.name}: {e}")
+            raise yaml.YAMLError(
+                f"Error parsing YAML file {yaml_file.name}: {e}"
+            ) from e
         except Exception as e:
-            raise ValueError(f"Error processing rule file {yaml_file.name}: {e}")
+            raise ValueError(f"Error processing rule file {yaml_file.name}: {e}") from e
 
     return rules
 

--- a/test_gen/rule_engine/tests/test_rules_loader.py
+++ b/test_gen/rule_engine/tests/test_rules_loader.py
@@ -12,8 +12,8 @@ from typing import List
 
 import yaml
 
-from test_gen.rule_engine.rules_loader import load_rules
-from test_gen.rule_engine.models import Rule
+from rule_engine.rules_loader import load_rules
+from rule_engine.models import Rule
 
 
 class TestRulesLoader:

--- a/test_gen/rule_engine/tests/test_rules_loader.py
+++ b/test_gen/rule_engine/tests/test_rules_loader.py
@@ -4,12 +4,10 @@ Tests for the rules_loader module.
 This module contains unit tests for loading and validating rules from YAML files.
 """
 
-import os
 import tempfile
-import pytest
 from pathlib import Path
-from typing import List
 
+import pytest
 import yaml
 
 from rule_engine.rules_loader import load_rules
@@ -38,7 +36,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "test_rule.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 yaml.dump(rule_data, f)
 
             rules = load_rules(temp_dir)
@@ -74,9 +72,9 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create two rule files
-            with open(Path(temp_dir) / "rule1.yaml", "w") as f:
+            with open(Path(temp_dir) / "rule1.yaml", "w", encoding="utf-8") as f:
                 yaml.dump(rule1, f)
-            with open(Path(temp_dir) / "rule2.yml", "w") as f:
+            with open(Path(temp_dir) / "rule2.yml", "w", encoding="utf-8") as f:
                 yaml.dump(rule2, f)
 
             rules = load_rules(temp_dir)
@@ -98,7 +96,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "minimal.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 yaml.dump(rule_data, f)
 
             rules = load_rules(temp_dir)
@@ -119,7 +117,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "incomplete.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 yaml.dump(incomplete_rule, f)
 
             with pytest.raises(ValueError) as exc_info:
@@ -141,7 +139,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "invalid.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 yaml.dump(rule_with_invalid_confidence, f)
 
             with pytest.raises(ValueError) as exc_info:
@@ -162,7 +160,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "wrong_types.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 yaml.dump(rule_with_wrong_types, f)
 
             with pytest.raises(ValueError) as exc_info:
@@ -182,7 +180,7 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             rule_file = Path(temp_dir) / "malformed.yaml"
-            with open(rule_file, "w") as f:
+            with open(rule_file, "w", encoding="utf-8") as f:
                 f.write(malformed_yaml)
 
             with pytest.raises(yaml.YAMLError):
@@ -205,7 +203,7 @@ class TestRulesLoader:
         """Test that empty directory returns empty list."""
         with tempfile.TemporaryDirectory() as temp_dir:
             rules = load_rules(temp_dir)
-            assert rules == []
+            assert not rules
 
     def test_directory_with_non_yaml_files_ignores_them(self):
         """Test that non-YAML files are ignored."""
@@ -219,13 +217,13 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a valid YAML file
-            with open(Path(temp_dir) / "valid.yaml", "w") as f:
+            with open(Path(temp_dir) / "valid.yaml", "w", encoding="utf-8") as f:
                 yaml.dump(rule_data, f)
 
             # Create non-YAML files that should be ignored
-            with open(Path(temp_dir) / "readme.txt", "w") as f:
+            with open(Path(temp_dir) / "readme.txt", "w", encoding="utf-8") as f:
                 f.write("This is not a rule file")
-            with open(Path(temp_dir) / "config.json", "w") as f:
+            with open(Path(temp_dir) / "config.json", "w", encoding="utf-8") as f:
                 f.write('{"not": "a rule"}')
 
             rules = load_rules(temp_dir)
@@ -245,11 +243,11 @@ class TestRulesLoader:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a valid rule file
-            with open(Path(temp_dir) / "valid.yaml", "w") as f:
+            with open(Path(temp_dir) / "valid.yaml", "w", encoding="utf-8") as f:
                 yaml.dump(rule_data, f)
 
             # Create an empty YAML file
-            with open(Path(temp_dir) / "empty.yaml", "w") as f:
+            with open(Path(temp_dir) / "empty.yaml", "w", encoding="utf-8") as f:
                 pass  # Empty file
 
             rules = load_rules(temp_dir)

--- a/test_gen/rule_engine/tests/test_rules_loader.py
+++ b/test_gen/rule_engine/tests/test_rules_loader.py
@@ -1,0 +1,265 @@
+"""
+Tests for the rules_loader module.
+
+This module contains unit tests for loading and validating rules from YAML files.
+"""
+
+import os
+import tempfile
+import pytest
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from test_gen.rule_engine.rules_loader import load_rules
+from test_gen.rule_engine.models import Rule
+
+
+class TestRulesLoader:
+    """Test cases for the rules_loader module."""
+    
+    def test_load_valid_single_rule(self):
+        """Test loading a single valid rule file."""
+        rule_data = {
+            'id': 'search_input_basic',
+            'description': 'Detects a user typing into a search box',
+            'match': {
+                'event': {
+                    'action': 'input'
+                },
+                'node': {
+                    'tag': 'input',
+                    'attributes': {
+                        'type': 'search'
+                    }
+                }
+            },
+            'confidence': 0.8,
+            'variables': {
+                'input_value': 'event.value',
+                'placeholder': 'node.attributes.placeholder'
+            },
+            'action_id': 'search_query'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'test_rule.yaml'
+            with open(rule_file, 'w') as f:
+                yaml.dump(rule_data, f)
+            
+            rules = load_rules(temp_dir)
+            
+            assert len(rules) == 1
+            rule = rules[0]
+            assert isinstance(rule, Rule)
+            assert rule.id == 'search_input_basic'
+            assert rule.description == 'Detects a user typing into a search box'
+            assert rule.confidence == 0.8
+            assert rule.action_id == 'search_query'
+            assert rule.match == rule_data['match']
+            assert rule.variables == rule_data['variables']
+    
+    def test_load_multiple_rules(self):
+        """Test loading multiple rule files from a directory."""
+        rule1 = {
+            'id': 'rule1',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 0.9,
+            'variables': {'target': 'node.id'},
+            'action_id': 'button_click'
+        }
+        
+        rule2 = {
+            'id': 'rule2',
+            'description': 'Second rule',
+            'match': {'event': {'action': 'input'}},
+            'confidence': 0.7,
+            'variables': {'value': 'event.value'},
+            'action_id': 'text_input'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create two rule files
+            with open(Path(temp_dir) / 'rule1.yaml', 'w') as f:
+                yaml.dump(rule1, f)
+            with open(Path(temp_dir) / 'rule2.yml', 'w') as f:
+                yaml.dump(rule2, f)
+            
+            rules = load_rules(temp_dir)
+            
+            assert len(rules) == 2
+            rule_ids = [rule.id for rule in rules]
+            assert 'rule1' in rule_ids
+            assert 'rule2' in rule_ids
+    
+    def test_load_rule_without_description(self):
+        """Test loading a rule without optional description field."""
+        rule_data = {
+            'id': 'minimal_rule',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 0.5,
+            'variables': {},
+            'action_id': 'click_action'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'minimal.yaml'
+            with open(rule_file, 'w') as f:
+                yaml.dump(rule_data, f)
+            
+            rules = load_rules(temp_dir)
+            
+            assert len(rules) == 1
+            rule = rules[0]
+            assert rule.id == 'minimal_rule'
+            assert rule.description is None
+    
+    def test_missing_required_field_raises_error(self):
+        """Test that missing required fields raise ValueError."""
+        incomplete_rule = {
+            'id': 'incomplete_rule',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 0.8
+            # Missing 'variables' and 'action_id'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'incomplete.yaml'
+            with open(rule_file, 'w') as f:
+                yaml.dump(incomplete_rule, f)
+            
+            with pytest.raises(ValueError) as exc_info:
+                load_rules(temp_dir)
+            
+            assert "missing required fields" in str(exc_info.value)
+            assert "variables" in str(exc_info.value)
+            assert "action_id" in str(exc_info.value)
+    
+    def test_invalid_confidence_value_raises_error(self):
+        """Test that invalid confidence values raise ValueError."""
+        rule_with_invalid_confidence = {
+            'id': 'invalid_confidence',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 1.5,  # Invalid: > 1
+            'variables': {},
+            'action_id': 'click_action'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'invalid.yaml'
+            with open(rule_file, 'w') as f:
+                yaml.dump(rule_with_invalid_confidence, f)
+            
+            with pytest.raises(ValueError) as exc_info:
+                load_rules(temp_dir)
+            
+            assert "confidence" in str(exc_info.value)
+            assert "between 0 and 1" in str(exc_info.value)
+    
+    def test_invalid_field_types_raise_error(self):
+        """Test that invalid field types raise ValueError."""
+        rule_with_wrong_types = {
+            'id': 123,  # Should be string
+            'match': "not a dict",  # Should be dict
+            'confidence': 0.8,
+            'variables': "not a dict",  # Should be dict
+            'action_id': ['not', 'a', 'string']  # Should be string
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'wrong_types.yaml'
+            with open(rule_file, 'w') as f:
+                yaml.dump(rule_with_wrong_types, f)
+            
+            with pytest.raises(ValueError) as exc_info:
+                load_rules(temp_dir)
+            
+            assert "must be a string" in str(exc_info.value)
+    
+    def test_malformed_yaml_raises_error(self):
+        """Test that malformed YAML files raise YAMLError."""
+        malformed_yaml = """
+        id: test_rule
+        match:
+          event:
+            action: click
+          invalid_yaml: [unclosed bracket
+        """
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rule_file = Path(temp_dir) / 'malformed.yaml'
+            with open(rule_file, 'w') as f:
+                f.write(malformed_yaml)
+            
+            with pytest.raises(yaml.YAMLError):
+                load_rules(temp_dir)
+    
+    def test_nonexistent_directory_raises_error(self):
+        """Test that nonexistent directory raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_rules('/nonexistent/directory')
+    
+    def test_file_path_instead_of_directory_raises_error(self):
+        """Test that passing a file path instead of directory raises ValueError."""
+        with tempfile.NamedTemporaryFile(suffix='.yaml') as temp_file:
+            with pytest.raises(ValueError) as exc_info:
+                load_rules(temp_file.name)
+            
+            assert "not a directory" in str(exc_info.value)
+    
+    def test_empty_directory_returns_empty_list(self):
+        """Test that empty directory returns empty list."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rules = load_rules(temp_dir)
+            assert rules == []
+    
+    def test_directory_with_non_yaml_files_ignores_them(self):
+        """Test that non-YAML files are ignored."""
+        rule_data = {
+            'id': 'valid_rule',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 0.8,
+            'variables': {},
+            'action_id': 'click_action'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a valid YAML file
+            with open(Path(temp_dir) / 'valid.yaml', 'w') as f:
+                yaml.dump(rule_data, f)
+            
+            # Create non-YAML files that should be ignored
+            with open(Path(temp_dir) / 'readme.txt', 'w') as f:
+                f.write('This is not a rule file')
+            with open(Path(temp_dir) / 'config.json', 'w') as f:
+                f.write('{"not": "a rule"}')
+            
+            rules = load_rules(temp_dir)
+            
+            assert len(rules) == 1
+            assert rules[0].id == 'valid_rule'
+    
+    def test_empty_yaml_file_is_skipped(self):
+        """Test that empty YAML files are skipped."""
+        rule_data = {
+            'id': 'valid_rule',
+            'match': {'event': {'action': 'click'}},
+            'confidence': 0.8,
+            'variables': {},
+            'action_id': 'click_action'
+        }
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a valid rule file
+            with open(Path(temp_dir) / 'valid.yaml', 'w') as f:
+                yaml.dump(rule_data, f)
+            
+            # Create an empty YAML file
+            with open(Path(temp_dir) / 'empty.yaml', 'w') as f:
+                pass  # Empty file
+            
+            rules = load_rules(temp_dir)
+            
+            assert len(rules) == 1
+            assert rules[0].id == 'valid_rule'

--- a/test_gen/rule_engine/tests/test_rules_loader.py
+++ b/test_gen/rule_engine/tests/test_rules_loader.py
@@ -18,165 +18,158 @@ from test_gen.rule_engine.models import Rule
 
 class TestRulesLoader:
     """Test cases for the rules_loader module."""
-    
+
     def test_load_valid_single_rule(self):
         """Test loading a single valid rule file."""
         rule_data = {
-            'id': 'search_input_basic',
-            'description': 'Detects a user typing into a search box',
-            'match': {
-                'event': {
-                    'action': 'input'
-                },
-                'node': {
-                    'tag': 'input',
-                    'attributes': {
-                        'type': 'search'
-                    }
-                }
+            "id": "search_input_basic",
+            "description": "Detects a user typing into a search box",
+            "match": {
+                "event": {"action": "input"},
+                "node": {"tag": "input", "attributes": {"type": "search"}},
             },
-            'confidence': 0.8,
-            'variables': {
-                'input_value': 'event.value',
-                'placeholder': 'node.attributes.placeholder'
+            "confidence": 0.8,
+            "variables": {
+                "input_value": "event.value",
+                "placeholder": "node.attributes.placeholder",
             },
-            'action_id': 'search_query'
+            "action_id": "search_query",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'test_rule.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "test_rule.yaml"
+            with open(rule_file, "w") as f:
                 yaml.dump(rule_data, f)
-            
+
             rules = load_rules(temp_dir)
-            
+
             assert len(rules) == 1
             rule = rules[0]
             assert isinstance(rule, Rule)
-            assert rule.id == 'search_input_basic'
-            assert rule.description == 'Detects a user typing into a search box'
+            assert rule.id == "search_input_basic"
+            assert rule.description == "Detects a user typing into a search box"
             assert rule.confidence == 0.8
-            assert rule.action_id == 'search_query'
-            assert rule.match == rule_data['match']
-            assert rule.variables == rule_data['variables']
-    
+            assert rule.action_id == "search_query"
+            assert rule.match == rule_data["match"]
+            assert rule.variables == rule_data["variables"]
+
     def test_load_multiple_rules(self):
         """Test loading multiple rule files from a directory."""
         rule1 = {
-            'id': 'rule1',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 0.9,
-            'variables': {'target': 'node.id'},
-            'action_id': 'button_click'
+            "id": "rule1",
+            "match": {"event": {"action": "click"}},
+            "confidence": 0.9,
+            "variables": {"target": "node.id"},
+            "action_id": "button_click",
         }
-        
+
         rule2 = {
-            'id': 'rule2',
-            'description': 'Second rule',
-            'match': {'event': {'action': 'input'}},
-            'confidence': 0.7,
-            'variables': {'value': 'event.value'},
-            'action_id': 'text_input'
+            "id": "rule2",
+            "description": "Second rule",
+            "match": {"event": {"action": "input"}},
+            "confidence": 0.7,
+            "variables": {"value": "event.value"},
+            "action_id": "text_input",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create two rule files
-            with open(Path(temp_dir) / 'rule1.yaml', 'w') as f:
+            with open(Path(temp_dir) / "rule1.yaml", "w") as f:
                 yaml.dump(rule1, f)
-            with open(Path(temp_dir) / 'rule2.yml', 'w') as f:
+            with open(Path(temp_dir) / "rule2.yml", "w") as f:
                 yaml.dump(rule2, f)
-            
+
             rules = load_rules(temp_dir)
-            
+
             assert len(rules) == 2
             rule_ids = [rule.id for rule in rules]
-            assert 'rule1' in rule_ids
-            assert 'rule2' in rule_ids
-    
+            assert "rule1" in rule_ids
+            assert "rule2" in rule_ids
+
     def test_load_rule_without_description(self):
         """Test loading a rule without optional description field."""
         rule_data = {
-            'id': 'minimal_rule',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 0.5,
-            'variables': {},
-            'action_id': 'click_action'
+            "id": "minimal_rule",
+            "match": {"event": {"action": "click"}},
+            "confidence": 0.5,
+            "variables": {},
+            "action_id": "click_action",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'minimal.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "minimal.yaml"
+            with open(rule_file, "w") as f:
                 yaml.dump(rule_data, f)
-            
+
             rules = load_rules(temp_dir)
-            
+
             assert len(rules) == 1
             rule = rules[0]
-            assert rule.id == 'minimal_rule'
+            assert rule.id == "minimal_rule"
             assert rule.description is None
-    
+
     def test_missing_required_field_raises_error(self):
         """Test that missing required fields raise ValueError."""
         incomplete_rule = {
-            'id': 'incomplete_rule',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 0.8
+            "id": "incomplete_rule",
+            "match": {"event": {"action": "click"}},
+            "confidence": 0.8,
             # Missing 'variables' and 'action_id'
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'incomplete.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "incomplete.yaml"
+            with open(rule_file, "w") as f:
                 yaml.dump(incomplete_rule, f)
-            
+
             with pytest.raises(ValueError) as exc_info:
                 load_rules(temp_dir)
-            
+
             assert "missing required fields" in str(exc_info.value)
             assert "variables" in str(exc_info.value)
             assert "action_id" in str(exc_info.value)
-    
+
     def test_invalid_confidence_value_raises_error(self):
         """Test that invalid confidence values raise ValueError."""
         rule_with_invalid_confidence = {
-            'id': 'invalid_confidence',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 1.5,  # Invalid: > 1
-            'variables': {},
-            'action_id': 'click_action'
+            "id": "invalid_confidence",
+            "match": {"event": {"action": "click"}},
+            "confidence": 1.5,  # Invalid: > 1
+            "variables": {},
+            "action_id": "click_action",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'invalid.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "invalid.yaml"
+            with open(rule_file, "w") as f:
                 yaml.dump(rule_with_invalid_confidence, f)
-            
+
             with pytest.raises(ValueError) as exc_info:
                 load_rules(temp_dir)
-            
+
             assert "confidence" in str(exc_info.value)
             assert "between 0 and 1" in str(exc_info.value)
-    
+
     def test_invalid_field_types_raise_error(self):
         """Test that invalid field types raise ValueError."""
         rule_with_wrong_types = {
-            'id': 123,  # Should be string
-            'match': "not a dict",  # Should be dict
-            'confidence': 0.8,
-            'variables': "not a dict",  # Should be dict
-            'action_id': ['not', 'a', 'string']  # Should be string
+            "id": 123,  # Should be string
+            "match": "not a dict",  # Should be dict
+            "confidence": 0.8,
+            "variables": "not a dict",  # Should be dict
+            "action_id": ["not", "a", "string"],  # Should be string
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'wrong_types.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "wrong_types.yaml"
+            with open(rule_file, "w") as f:
                 yaml.dump(rule_with_wrong_types, f)
-            
+
             with pytest.raises(ValueError) as exc_info:
                 load_rules(temp_dir)
-            
+
             assert "must be a string" in str(exc_info.value)
-    
+
     def test_malformed_yaml_raises_error(self):
         """Test that malformed YAML files raise YAMLError."""
         malformed_yaml = """
@@ -186,80 +179,80 @@ class TestRulesLoader:
             action: click
           invalid_yaml: [unclosed bracket
         """
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            rule_file = Path(temp_dir) / 'malformed.yaml'
-            with open(rule_file, 'w') as f:
+            rule_file = Path(temp_dir) / "malformed.yaml"
+            with open(rule_file, "w") as f:
                 f.write(malformed_yaml)
-            
+
             with pytest.raises(yaml.YAMLError):
                 load_rules(temp_dir)
-    
+
     def test_nonexistent_directory_raises_error(self):
         """Test that nonexistent directory raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            load_rules('/nonexistent/directory')
-    
+            load_rules("/nonexistent/directory")
+
     def test_file_path_instead_of_directory_raises_error(self):
         """Test that passing a file path instead of directory raises ValueError."""
-        with tempfile.NamedTemporaryFile(suffix='.yaml') as temp_file:
+        with tempfile.NamedTemporaryFile(suffix=".yaml") as temp_file:
             with pytest.raises(ValueError) as exc_info:
                 load_rules(temp_file.name)
-            
+
             assert "not a directory" in str(exc_info.value)
-    
+
     def test_empty_directory_returns_empty_list(self):
         """Test that empty directory returns empty list."""
         with tempfile.TemporaryDirectory() as temp_dir:
             rules = load_rules(temp_dir)
             assert rules == []
-    
+
     def test_directory_with_non_yaml_files_ignores_them(self):
         """Test that non-YAML files are ignored."""
         rule_data = {
-            'id': 'valid_rule',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 0.8,
-            'variables': {},
-            'action_id': 'click_action'
+            "id": "valid_rule",
+            "match": {"event": {"action": "click"}},
+            "confidence": 0.8,
+            "variables": {},
+            "action_id": "click_action",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a valid YAML file
-            with open(Path(temp_dir) / 'valid.yaml', 'w') as f:
+            with open(Path(temp_dir) / "valid.yaml", "w") as f:
                 yaml.dump(rule_data, f)
-            
+
             # Create non-YAML files that should be ignored
-            with open(Path(temp_dir) / 'readme.txt', 'w') as f:
-                f.write('This is not a rule file')
-            with open(Path(temp_dir) / 'config.json', 'w') as f:
+            with open(Path(temp_dir) / "readme.txt", "w") as f:
+                f.write("This is not a rule file")
+            with open(Path(temp_dir) / "config.json", "w") as f:
                 f.write('{"not": "a rule"}')
-            
+
             rules = load_rules(temp_dir)
-            
+
             assert len(rules) == 1
-            assert rules[0].id == 'valid_rule'
-    
+            assert rules[0].id == "valid_rule"
+
     def test_empty_yaml_file_is_skipped(self):
         """Test that empty YAML files are skipped."""
         rule_data = {
-            'id': 'valid_rule',
-            'match': {'event': {'action': 'click'}},
-            'confidence': 0.8,
-            'variables': {},
-            'action_id': 'click_action'
+            "id": "valid_rule",
+            "match": {"event": {"action": "click"}},
+            "confidence": 0.8,
+            "variables": {},
+            "action_id": "click_action",
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a valid rule file
-            with open(Path(temp_dir) / 'valid.yaml', 'w') as f:
+            with open(Path(temp_dir) / "valid.yaml", "w") as f:
                 yaml.dump(rule_data, f)
-            
+
             # Create an empty YAML file
-            with open(Path(temp_dir) / 'empty.yaml', 'w') as f:
+            with open(Path(temp_dir) / "empty.yaml", "w") as f:
                 pass  # Empty file
-            
+
             rules = load_rules(temp_dir)
-            
+
             assert len(rules) == 1
-            assert rules[0].id == 'valid_rule'
+            assert rules[0].id == "valid_rule"


### PR DESCRIPTION
**What it accomplishes:**
Add support for loading YAML rule files from disk and converting them into `Rule` objects.

**How to verify:**

* Load all rules in `test_gen/data/rules/` directory
* Unit tests verify parsing of well-formed rule files
* Invalid or missing fields raise clean validation errors

--

Implements a rule loader module that loads YAML rule files from disk and converts them into Rule objects. The implementation supports directory-based rule loading with comprehensive validation and error handling.

Key changes:

- Added YAML rule file loading functionality with validation
- Added PyYAML dependency for YAML parsing
- Updated documentation and helper utilities for better workflow
