### PR TITLE
Add Variable Extraction (Direct Fields)

### DIFF
--- a/test_gen/docs/rules_based_action_matching/prompt_plan.md
+++ b/test_gen/docs/rules_based_action_matching/prompt_plan.md
@@ -276,6 +276,98 @@ Extract values from matched `event` and `node` based on the `variables:` section
   * `node.attributes.<key>`
 * Fallback or error behavior clearly defined (e.g., missing fields = None)
 
+**Detailed Prompt**
+
+You are working on a rule-based system that detects user actions from rrweb session data. Your task is to implement **variable extraction** logic based on the `variables:` block of a rule.
+
+This logic will be used after a rule has matched a `UserInteraction` and `UINode`.
+
+---
+
+#### ✅ Requirements
+
+Create or update the following module:
+📄 `test_gen/rule_engine/variable_resolver.py`
+
+Implement a function:
+
+```python
+def extract_variables(
+    variable_map: Dict[str, str],
+    event: UserInteraction,
+    node: UINode
+) -> Dict[str, Any]:
+    ...
+```
+
+Where:
+
+* `variable_map` comes from `rule.variables`
+* Keys are variable names to output (e.g., `input_value`)
+* Values are source paths (e.g., `"event.value"`, `"node.text"`, `"node.attributes.placeholder"`)
+
+The function should return a dictionary of resolved variable values:
+
+* Resolve paths dynamically
+* If a path does not exist, return `None` for that variable
+
+---
+
+#### 🧪 Examples
+
+Given this input:
+
+```yaml
+variables:
+  input_value: event.value
+  placeholder: node.attributes.placeholder
+  node_text: node.text
+```
+
+And a matching `event` and `node`, the function should return:
+
+```python
+{
+  "input_value": "cats",
+  "placeholder": "Search...",
+  "node_text": "Search field"
+}
+```
+
+If a key is missing (e.g., `node.attributes.placeholder` not present), return:
+
+```python
+{
+  "placeholder": None
+}
+```
+
+---
+
+#### 🧪 Testing
+
+Create this test file:
+📄 `test_gen/rule_engine/tests/test_variable_extraction.py`
+
+Write unit tests that:
+
+* Validate extraction from `event.value`, `node.text`
+* Validate attribute extraction like `node.attributes.placeholder`
+* Validate missing attributes return `None`
+* Validate handling of invalid or unknown paths (e.g., `node.foo.bar`)
+
+Use simple mock `UserInteraction` and `UINode` objects.
+
+---
+
+#### ✅ Deliverables
+
+* `extract_variables(variable_map, event, node)` in `variable_resolver.py`
+* Full test coverage in `test_variable_extraction.py`
+* Logic limited to flat access for now (no CSS selectors yet)
+
+Let me know when you’re ready for Step 5: Emitting `DetectedAction` objects.
+
 ---
 
 ### **Step 5: Emit `DetectedAction` for Matches**

--- a/test_gen/rule_engine/tests/test_variable_extraction.py
+++ b/test_gen/rule_engine/tests/test_variable_extraction.py
@@ -12,17 +12,14 @@ from feature_extraction.models import UserInteraction, UINode
 
 class TestExtractVariables:
     """Test cases for the extract_variables function."""
-    
+
     def setup_method(self):
         """Set up test fixtures for each test method."""
         # Mock UserInteraction with typical click event data
         self.event = UserInteraction(
-            action="input",
-            target_id=123,
-            value="cats",
-            timestamp=1000
+            action="input", target_id=123, value="cats", timestamp=1000
         )
-        
+
         # Mock UINode with typical input field data
         self.node = UINode(
             id=123,
@@ -30,192 +27,180 @@ class TestExtractVariables:
             attributes={
                 "placeholder": "Search...",
                 "type": "text",
-                "name": "search_query"
+                "name": "search_query",
             },
             text="Search field",
-            parent=456
+            parent=456,
         )
-    
+
     def test_extract_event_value(self):
         """Test extraction of event.value."""
         variable_map = {"input_value": "event.value"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"input_value": "cats"}
-    
+
     def test_extract_node_text(self):
         """Test extraction of node.text."""
         variable_map = {"node_text": "node.text"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"node_text": "Search field"}
-    
+
     def test_extract_node_attribute(self):
         """Test extraction of node attributes."""
         variable_map = {"placeholder": "node.attributes.placeholder"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"placeholder": "Search..."}
-    
+
     def test_extract_multiple_variables(self):
         """Test extraction of multiple variables in one call."""
         variable_map = {
             "input_value": "event.value",
             "placeholder": "node.attributes.placeholder",
             "node_text": "node.text",
-            "field_type": "node.attributes.type"
+            "field_type": "node.attributes.type",
         }
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         expected = {
             "input_value": "cats",
             "placeholder": "Search...",
             "node_text": "Search field",
-            "field_type": "text"
+            "field_type": "text",
         }
         assert result == expected
-    
+
     def test_missing_attribute_returns_none(self):
         """Test that missing attributes return None."""
         variable_map = {"missing_attr": "node.attributes.nonexistent"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"missing_attr": None}
-    
+
     def test_missing_event_field_returns_none(self):
         """Test that missing event fields return None."""
         variable_map = {"missing_field": "event.nonexistent"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"missing_field": None}
-    
+
     def test_missing_node_field_returns_none(self):
         """Test that missing node fields return None."""
         variable_map = {"missing_field": "node.nonexistent"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"missing_field": None}
-    
+
     def test_invalid_path_root_returns_none(self):
         """Test that invalid path roots return None."""
         variable_map = {"invalid": "invalid_root.field"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"invalid": None}
-    
+
     def test_deeply_nested_invalid_path_returns_none(self):
         """Test that deeply nested invalid paths return None."""
         variable_map = {"invalid": "node.foo.bar.baz"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"invalid": None}
-    
+
     def test_single_part_path_returns_none(self):
         """Test that single-part paths return None."""
         variable_map = {"invalid": "event"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"invalid": None}
-    
+
     def test_empty_path_returns_none(self):
         """Test that empty paths return None."""
         variable_map = {"invalid": ""}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"invalid": None}
-    
+
     def test_event_action_extraction(self):
         """Test extraction of event.action."""
         variable_map = {"action_type": "event.action"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"action_type": "input"}
-    
+
     def test_event_timestamp_extraction(self):
         """Test extraction of event.timestamp."""
         variable_map = {"event_time": "event.timestamp"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"event_time": 1000}
-    
+
     def test_node_id_extraction(self):
         """Test extraction of node.id."""
         variable_map = {"node_id": "node.id"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"node_id": 123}
-    
+
     def test_node_tag_extraction(self):
         """Test extraction of node.tag."""
         variable_map = {"element_tag": "node.tag"}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {"element_tag": "input"}
-    
+
     def test_empty_variable_map(self):
         """Test that empty variable map returns empty result."""
         variable_map = {}
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         assert result == {}
-    
+
     def test_node_with_empty_attributes(self):
         """Test extraction from node with empty attributes."""
-        empty_node = UINode(
-            id=789,
-            tag="div",
-            attributes={},
-            text="",
-            parent=None
-        )
-        
+        empty_node = UINode(id=789, tag="div", attributes={}, text="", parent=None)
+
         variable_map = {"missing_attr": "node.attributes.placeholder"}
         result = extract_variables(variable_map, self.event, empty_node)
-        
+
         assert result == {"missing_attr": None}
-    
+
     def test_event_with_none_value(self):
         """Test extraction from event with None value."""
         none_event = UserInteraction(
-            action="click",
-            target_id=456,
-            value=None,
-            timestamp=2000
+            action="click", target_id=456, value=None, timestamp=2000
         )
-        
+
         variable_map = {"event_value": "event.value"}
         result = extract_variables(variable_map, none_event, self.node)
-        
+
         assert result == {"event_value": None}
-    
+
     def test_event_with_complex_value(self):
         """Test extraction from event with complex value (dict/list)."""
         complex_event = UserInteraction(
-            action="scroll",
-            target_id=789,
-            value={"x": 100, "y": 200},
-            timestamp=3000
+            action="scroll", target_id=789, value={"x": 100, "y": 200}, timestamp=3000
         )
-        
+
         variable_map = {"scroll_data": "event.value"}
         result = extract_variables(variable_map, complex_event, self.node)
-        
+
         assert result == {"scroll_data": {"x": 100, "y": 200}}
-    
+
     def test_mixed_valid_and_invalid_paths(self):
         """Test extraction with mix of valid and invalid paths."""
         variable_map = {
             "valid_value": "event.value",
             "invalid_field": "event.nonexistent",
             "valid_placeholder": "node.attributes.placeholder",
-            "invalid_attr": "node.attributes.missing"
+            "invalid_attr": "node.attributes.missing",
         }
         result = extract_variables(variable_map, self.event, self.node)
-        
+
         expected = {
             "valid_value": "cats",
             "invalid_field": None,
             "valid_placeholder": "Search...",
-            "invalid_attr": None
+            "invalid_attr": None,
         }
         assert result == expected

--- a/test_gen/rule_engine/tests/test_variable_extraction.py
+++ b/test_gen/rule_engine/tests/test_variable_extraction.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for variable extraction functionality.
+
+Tests the extract_variables function with various scenarios including
+successful extractions, missing fields, and error handling.
+"""
+
+import pytest
+from rule_engine.variable_resolver import extract_variables
+from feature_extraction.models import UserInteraction, UINode
+
+
+class TestExtractVariables:
+    """Test cases for the extract_variables function."""
+    
+    def setup_method(self):
+        """Set up test fixtures for each test method."""
+        # Mock UserInteraction with typical click event data
+        self.event = UserInteraction(
+            action="input",
+            target_id=123,
+            value="cats",
+            timestamp=1000
+        )
+        
+        # Mock UINode with typical input field data
+        self.node = UINode(
+            id=123,
+            tag="input",
+            attributes={
+                "placeholder": "Search...",
+                "type": "text",
+                "name": "search_query"
+            },
+            text="Search field",
+            parent=456
+        )
+    
+    def test_extract_event_value(self):
+        """Test extraction of event.value."""
+        variable_map = {"input_value": "event.value"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"input_value": "cats"}
+    
+    def test_extract_node_text(self):
+        """Test extraction of node.text."""
+        variable_map = {"node_text": "node.text"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"node_text": "Search field"}
+    
+    def test_extract_node_attribute(self):
+        """Test extraction of node attributes."""
+        variable_map = {"placeholder": "node.attributes.placeholder"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"placeholder": "Search..."}
+    
+    def test_extract_multiple_variables(self):
+        """Test extraction of multiple variables in one call."""
+        variable_map = {
+            "input_value": "event.value",
+            "placeholder": "node.attributes.placeholder",
+            "node_text": "node.text",
+            "field_type": "node.attributes.type"
+        }
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        expected = {
+            "input_value": "cats",
+            "placeholder": "Search...",
+            "node_text": "Search field",
+            "field_type": "text"
+        }
+        assert result == expected
+    
+    def test_missing_attribute_returns_none(self):
+        """Test that missing attributes return None."""
+        variable_map = {"missing_attr": "node.attributes.nonexistent"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"missing_attr": None}
+    
+    def test_missing_event_field_returns_none(self):
+        """Test that missing event fields return None."""
+        variable_map = {"missing_field": "event.nonexistent"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"missing_field": None}
+    
+    def test_missing_node_field_returns_none(self):
+        """Test that missing node fields return None."""
+        variable_map = {"missing_field": "node.nonexistent"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"missing_field": None}
+    
+    def test_invalid_path_root_returns_none(self):
+        """Test that invalid path roots return None."""
+        variable_map = {"invalid": "invalid_root.field"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"invalid": None}
+    
+    def test_deeply_nested_invalid_path_returns_none(self):
+        """Test that deeply nested invalid paths return None."""
+        variable_map = {"invalid": "node.foo.bar.baz"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"invalid": None}
+    
+    def test_single_part_path_returns_none(self):
+        """Test that single-part paths return None."""
+        variable_map = {"invalid": "event"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"invalid": None}
+    
+    def test_empty_path_returns_none(self):
+        """Test that empty paths return None."""
+        variable_map = {"invalid": ""}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"invalid": None}
+    
+    def test_event_action_extraction(self):
+        """Test extraction of event.action."""
+        variable_map = {"action_type": "event.action"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"action_type": "input"}
+    
+    def test_event_timestamp_extraction(self):
+        """Test extraction of event.timestamp."""
+        variable_map = {"event_time": "event.timestamp"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"event_time": 1000}
+    
+    def test_node_id_extraction(self):
+        """Test extraction of node.id."""
+        variable_map = {"node_id": "node.id"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"node_id": 123}
+    
+    def test_node_tag_extraction(self):
+        """Test extraction of node.tag."""
+        variable_map = {"element_tag": "node.tag"}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {"element_tag": "input"}
+    
+    def test_empty_variable_map(self):
+        """Test that empty variable map returns empty result."""
+        variable_map = {}
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        assert result == {}
+    
+    def test_node_with_empty_attributes(self):
+        """Test extraction from node with empty attributes."""
+        empty_node = UINode(
+            id=789,
+            tag="div",
+            attributes={},
+            text="",
+            parent=None
+        )
+        
+        variable_map = {"missing_attr": "node.attributes.placeholder"}
+        result = extract_variables(variable_map, self.event, empty_node)
+        
+        assert result == {"missing_attr": None}
+    
+    def test_event_with_none_value(self):
+        """Test extraction from event with None value."""
+        none_event = UserInteraction(
+            action="click",
+            target_id=456,
+            value=None,
+            timestamp=2000
+        )
+        
+        variable_map = {"event_value": "event.value"}
+        result = extract_variables(variable_map, none_event, self.node)
+        
+        assert result == {"event_value": None}
+    
+    def test_event_with_complex_value(self):
+        """Test extraction from event with complex value (dict/list)."""
+        complex_event = UserInteraction(
+            action="scroll",
+            target_id=789,
+            value={"x": 100, "y": 200},
+            timestamp=3000
+        )
+        
+        variable_map = {"scroll_data": "event.value"}
+        result = extract_variables(variable_map, complex_event, self.node)
+        
+        assert result == {"scroll_data": {"x": 100, "y": 200}}
+    
+    def test_mixed_valid_and_invalid_paths(self):
+        """Test extraction with mix of valid and invalid paths."""
+        variable_map = {
+            "valid_value": "event.value",
+            "invalid_field": "event.nonexistent",
+            "valid_placeholder": "node.attributes.placeholder",
+            "invalid_attr": "node.attributes.missing"
+        }
+        result = extract_variables(variable_map, self.event, self.node)
+        
+        expected = {
+            "valid_value": "cats",
+            "invalid_field": None,
+            "valid_placeholder": "Search...",
+            "invalid_attr": None
+        }
+        assert result == expected

--- a/test_gen/rule_engine/tests/test_variable_extraction.py
+++ b/test_gen/rule_engine/tests/test_variable_extraction.py
@@ -6,201 +6,222 @@ successful extractions, missing fields, and error handling.
 """
 
 import pytest
+
 from rule_engine.variable_resolver import extract_variables
 from feature_extraction.models import UserInteraction, UINode
 
 
-class TestExtractVariables:
-    """Test cases for the extract_variables function."""
+@pytest.fixture(name="mock_event")
+def fixture_mock_event():
+    """Set up test fixtures for each test method."""
+    # Mock UserInteraction with typical click event data
+    return UserInteraction(action="input", target_id=123, value="cats", timestamp=1000)
 
-    def setup_method(self):
-        """Set up test fixtures for each test method."""
-        # Mock UserInteraction with typical click event data
-        self.event = UserInteraction(
-            action="input", target_id=123, value="cats", timestamp=1000
-        )
 
-        # Mock UINode with typical input field data
-        self.node = UINode(
-            id=123,
-            tag="input",
-            attributes={
-                "placeholder": "Search...",
-                "type": "text",
-                "name": "search_query",
-            },
-            text="Search field",
-            parent=456,
-        )
-
-    def test_extract_event_value(self):
-        """Test extraction of event.value."""
-        variable_map = {"input_value": "event.value"}
-        result = extract_variables(variable_map, self.event, self.node)
-
-        assert result == {"input_value": "cats"}
-
-    def test_extract_node_text(self):
-        """Test extraction of node.text."""
-        variable_map = {"node_text": "node.text"}
-        result = extract_variables(variable_map, self.event, self.node)
-
-        assert result == {"node_text": "Search field"}
-
-    def test_extract_node_attribute(self):
-        """Test extraction of node attributes."""
-        variable_map = {"placeholder": "node.attributes.placeholder"}
-        result = extract_variables(variable_map, self.event, self.node)
-
-        assert result == {"placeholder": "Search..."}
-
-    def test_extract_multiple_variables(self):
-        """Test extraction of multiple variables in one call."""
-        variable_map = {
-            "input_value": "event.value",
-            "placeholder": "node.attributes.placeholder",
-            "node_text": "node.text",
-            "field_type": "node.attributes.type",
-        }
-        result = extract_variables(variable_map, self.event, self.node)
-
-        expected = {
-            "input_value": "cats",
+@pytest.fixture(name="mock_node")
+def fixture_mock_node():
+    """Set up test fixtures for each test method."""
+    # Mock UINode with typical input field data
+    return UINode(
+        id=123,
+        tag="input",
+        attributes={
             "placeholder": "Search...",
-            "node_text": "Search field",
-            "field_type": "text",
-        }
-        assert result == expected
+            "type": "text",
+            "name": "search_query",
+        },
+        text="Search field",
+        parent=456,
+    )
 
-    def test_missing_attribute_returns_none(self):
-        """Test that missing attributes return None."""
-        variable_map = {"missing_attr": "node.attributes.nonexistent"}
-        result = extract_variables(variable_map, self.event, self.node)
 
-        assert result == {"missing_attr": None}
+def test_extract_event_value(mock_event, mock_node):
+    """Test extraction of event.value."""
+    variable_map = {"input_value": "event.value"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-    def test_missing_event_field_returns_none(self):
-        """Test that missing event fields return None."""
-        variable_map = {"missing_field": "event.nonexistent"}
-        result = extract_variables(variable_map, self.event, self.node)
+    assert result == {"input_value": "cats"}
 
-        assert result == {"missing_field": None}
 
-    def test_missing_node_field_returns_none(self):
-        """Test that missing node fields return None."""
-        variable_map = {"missing_field": "node.nonexistent"}
-        result = extract_variables(variable_map, self.event, self.node)
+def test_extract_node_text(mock_event, mock_node):
+    """Test extraction of node.text."""
+    variable_map = {"node_text": "node.text"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"missing_field": None}
+    assert result == {"node_text": "Search field"}
 
-    def test_invalid_path_root_returns_none(self):
-        """Test that invalid path roots return None."""
-        variable_map = {"invalid": "invalid_root.field"}
-        result = extract_variables(variable_map, self.event, self.node)
 
-        assert result == {"invalid": None}
+def test_extract_node_attribute(mock_event, mock_node):
+    """Test extraction of node attributes."""
+    variable_map = {"placeholder": "node.attributes.placeholder"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-    def test_deeply_nested_invalid_path_returns_none(self):
-        """Test that deeply nested invalid paths return None."""
-        variable_map = {"invalid": "node.foo.bar.baz"}
-        result = extract_variables(variable_map, self.event, self.node)
+    assert result == {"placeholder": "Search..."}
 
-        assert result == {"invalid": None}
 
-    def test_single_part_path_returns_none(self):
-        """Test that single-part paths return None."""
-        variable_map = {"invalid": "event"}
-        result = extract_variables(variable_map, self.event, self.node)
+def test_extract_multiple_variables(mock_event, mock_node):
+    """Test extraction of multiple variables in one call."""
+    variable_map = {
+        "input_value": "event.value",
+        "placeholder": "node.attributes.placeholder",
+        "node_text": "node.text",
+        "field_type": "node.attributes.type",
+    }
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"invalid": None}
+    expected = {
+        "input_value": "cats",
+        "placeholder": "Search...",
+        "node_text": "Search field",
+        "field_type": "text",
+    }
+    assert result == expected
 
-    def test_empty_path_returns_none(self):
-        """Test that empty paths return None."""
-        variable_map = {"invalid": ""}
-        result = extract_variables(variable_map, self.event, self.node)
 
-        assert result == {"invalid": None}
+def test_missing_attribute_returns_none(mock_event, mock_node):
+    """Test that missing attributes return None."""
+    variable_map = {"missing_attr": "node.attributes.nonexistent"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-    def test_event_action_extraction(self):
-        """Test extraction of event.action."""
-        variable_map = {"action_type": "event.action"}
-        result = extract_variables(variable_map, self.event, self.node)
+    assert result == {"missing_attr": None}
 
-        assert result == {"action_type": "input"}
 
-    def test_event_timestamp_extraction(self):
-        """Test extraction of event.timestamp."""
-        variable_map = {"event_time": "event.timestamp"}
-        result = extract_variables(variable_map, self.event, self.node)
+def test_missing_event_field_returns_none(mock_event, mock_node):
+    """Test that missing event fields return None."""
+    variable_map = {"missing_field": "event.nonexistent"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"event_time": 1000}
+    assert result == {"missing_field": None}
 
-    def test_node_id_extraction(self):
-        """Test extraction of node.id."""
-        variable_map = {"node_id": "node.id"}
-        result = extract_variables(variable_map, self.event, self.node)
 
-        assert result == {"node_id": 123}
+def test_missing_node_field_returns_none(mock_event, mock_node):
+    """Test that missing node fields return None."""
+    variable_map = {"missing_field": "node.nonexistent"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-    def test_node_tag_extraction(self):
-        """Test extraction of node.tag."""
-        variable_map = {"element_tag": "node.tag"}
-        result = extract_variables(variable_map, self.event, self.node)
+    assert result == {"missing_field": None}
 
-        assert result == {"element_tag": "input"}
 
-    def test_empty_variable_map(self):
-        """Test that empty variable map returns empty result."""
-        variable_map = {}
-        result = extract_variables(variable_map, self.event, self.node)
+def test_invalid_path_root_returns_none(mock_event, mock_node):
+    """Test that invalid path roots return None."""
+    variable_map = {"invalid": "invalid_root.field"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {}
+    assert result == {"invalid": None}
 
-    def test_node_with_empty_attributes(self):
-        """Test extraction from node with empty attributes."""
-        empty_node = UINode(id=789, tag="div", attributes={}, text="", parent=None)
 
-        variable_map = {"missing_attr": "node.attributes.placeholder"}
-        result = extract_variables(variable_map, self.event, empty_node)
+def test_deeply_nested_invalid_path_returns_none(mock_event, mock_node):
+    """Test that deeply nested invalid paths return None."""
+    variable_map = {"invalid": "node.foo.bar.baz"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"missing_attr": None}
+    assert result == {"invalid": None}
 
-    def test_event_with_none_value(self):
-        """Test extraction from event with None value."""
-        none_event = UserInteraction(
-            action="click", target_id=456, value=None, timestamp=2000
-        )
 
-        variable_map = {"event_value": "event.value"}
-        result = extract_variables(variable_map, none_event, self.node)
+def test_single_part_path_returns_none(mock_event, mock_node):
+    """Test that single-part paths return None."""
+    variable_map = {"invalid": "event"}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"event_value": None}
+    assert result == {"invalid": None}
 
-    def test_event_with_complex_value(self):
-        """Test extraction from event with complex value (dict/list)."""
-        complex_event = UserInteraction(
-            action="scroll", target_id=789, value={"x": 100, "y": 200}, timestamp=3000
-        )
 
-        variable_map = {"scroll_data": "event.value"}
-        result = extract_variables(variable_map, complex_event, self.node)
+def test_empty_path_returns_none(mock_event, mock_node):
+    """Test that empty paths return None."""
+    variable_map = {"invalid": ""}
+    result = extract_variables(variable_map, mock_event, mock_node)
 
-        assert result == {"scroll_data": {"x": 100, "y": 200}}
+    assert result == {"invalid": None}
 
-    def test_mixed_valid_and_invalid_paths(self):
-        """Test extraction with mix of valid and invalid paths."""
-        variable_map = {
-            "valid_value": "event.value",
-            "invalid_field": "event.nonexistent",
-            "valid_placeholder": "node.attributes.placeholder",
-            "invalid_attr": "node.attributes.missing",
-        }
-        result = extract_variables(variable_map, self.event, self.node)
 
-        expected = {
-            "valid_value": "cats",
-            "invalid_field": None,
-            "valid_placeholder": "Search...",
-            "invalid_attr": None,
-        }
-        assert result == expected
+def test_event_action_extraction(mock_event, mock_node):
+    """Test extraction of event.action."""
+    variable_map = {"action_type": "event.action"}
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    assert result == {"action_type": "input"}
+
+
+def test_event_timestamp_extraction(mock_event, mock_node):
+    """Test extraction of event.timestamp."""
+    variable_map = {"event_time": "event.timestamp"}
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    assert result == {"event_time": 1000}
+
+
+def test_node_id_extraction(mock_event, mock_node):
+    """Test extraction of node.id."""
+    variable_map = {"node_id": "node.id"}
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    assert result == {"node_id": 123}
+
+
+def test_node_tag_extraction(mock_event, mock_node):
+    """Test extraction of node.tag."""
+    variable_map = {"element_tag": "node.tag"}
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    assert result == {"element_tag": "input"}
+
+
+def test_empty_variable_map(mock_event, mock_node):
+    """Test that empty variable map returns empty result."""
+    variable_map = {}
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    assert not result
+
+
+def test_node_with_empty_attributes(mock_event):
+    """Test extraction from node with empty attributes."""
+    empty_node = UINode(id=789, tag="div", attributes={}, text="", parent=None)
+
+    variable_map = {"missing_attr": "node.attributes.placeholder"}
+    result = extract_variables(variable_map, mock_event, empty_node)
+
+    assert result == {"missing_attr": None}
+
+
+def test_event_with_none_value(mock_node):
+    """Test extraction from event with None value."""
+    none_event = UserInteraction(
+        action="click", target_id=456, value=None, timestamp=2000
+    )
+
+    variable_map = {"event_value": "event.value"}
+    result = extract_variables(variable_map, none_event, mock_node)
+
+    assert result == {"event_value": None}
+
+
+def test_event_with_complex_value(mock_node):
+    """Test extraction from event with complex value (dict/list)."""
+    complex_event = UserInteraction(
+        action="scroll", target_id=789, value={"x": 100, "y": 200}, timestamp=3000
+    )
+
+    variable_map = {"scroll_data": "event.value"}
+    result = extract_variables(variable_map, complex_event, mock_node)
+
+    assert result == {"scroll_data": {"x": 100, "y": 200}}
+
+
+def test_mixed_valid_and_invalid_paths(mock_event, mock_node):
+    """Test extraction with mix of valid and invalid paths."""
+    variable_map = {
+        "valid_value": "event.value",
+        "invalid_field": "event.nonexistent",
+        "valid_placeholder": "node.attributes.placeholder",
+        "invalid_attr": "node.attributes.missing",
+    }
+    result = extract_variables(variable_map, mock_event, mock_node)
+
+    expected = {
+        "valid_value": "cats",
+        "invalid_field": None,
+        "valid_placeholder": "Search...",
+        "invalid_attr": None,
+    }
+    assert result == expected

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -56,8 +56,7 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
         node: The UINode object
 
     Returns:
-        The resolved value, or None if the path cannot be resolved (including when AttributeError,
-        KeyError, or TypeError is raised).
+        The resolved value, or None if the path cannot be resolved.
     """
     path_parts = path.split(".")
 

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -10,23 +10,21 @@ from feature_extraction.models import UserInteraction, UINode
 
 
 def extract_variables(
-    variable_map: Dict[str, str],
-    event: UserInteraction,
-    node: UINode
+    variable_map: Dict[str, str], event: UserInteraction, node: UINode
 ) -> Dict[str, Any]:
     """
     Extract variables from matched event and node based on path expressions.
-    
+
     Args:
         variable_map: Dictionary mapping variable names to source paths
                      (e.g., {"input_value": "event.value", "placeholder": "node.attributes.placeholder"})
         event: The matched UserInteraction object
         node: The matched UINode object
-    
+
     Returns:
         Dictionary mapping variable names to their resolved values.
         Returns None for variables whose paths cannot be resolved.
-    
+
     Examples:
         >>> variable_map = {
         ...     "input_value": "event.value",
@@ -37,34 +35,34 @@ def extract_variables(
         >>> # Returns: {"input_value": "cats", "placeholder": "Search...", "node_text": "Search field"}
     """
     result = {}
-    
+
     for variable_name, path in variable_map.items():
         resolved_value = _resolve_path(path, event, node)
         result[variable_name] = resolved_value
-    
+
     return result
 
 
 def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
     """
     Resolve a dotted path expression to extract a value from event or node.
-    
+
     Args:
         path: Dotted path expression (e.g., "event.value", "node.text", "node.attributes.placeholder")
         event: The UserInteraction object
         node: The UINode object
-    
+
     Returns:
         The resolved value, or None if the path cannot be resolved.
     """
-    path_parts = path.split('.')
-    
+    path_parts = path.split(".")
+
     if len(path_parts) < 2:
         return None
-    
+
     root = path_parts[0]
     remaining_parts = path_parts[1:]
-    
+
     # Determine the root object
     if root == "event":
         current_obj = event
@@ -72,7 +70,7 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
         current_obj = node
     else:
         return None
-    
+
     # Traverse the path
     for part in remaining_parts:
         try:
@@ -84,5 +82,5 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
                 return None
         except (AttributeError, KeyError, TypeError):
             return None
-    
+
     return current_obj

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -45,7 +45,10 @@ def extract_variables(
 
 def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
     """
-    Resolve a dotted path expression to extract a value from event or node.
+    Private helper function to resolve a dotted path expression to extract a value from event or node.
+
+    This function returns None if the path cannot be resolved, specifically if an AttributeError,
+    KeyError, or TypeError is encountered during resolution.
 
     Args:
         path: Dotted path expression (e.g., "event.value", "node.text", "node.attributes.placeholder")
@@ -53,7 +56,8 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
         node: The UINode object
 
     Returns:
-        The resolved value, or None if the path cannot be resolved.
+        The resolved value, or None if the path cannot be resolved (including when AttributeError,
+        KeyError, or TypeError is raised).
     """
     path_parts = path.split(".")
 

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -1,0 +1,88 @@
+"""
+Variable resolution module for extracting values from matched events and nodes.
+
+This module provides functionality to extract variable values from UserInteraction
+events and UINode objects based on path expressions defined in rules.
+"""
+
+from typing import Dict, Any
+from feature_extraction.models import UserInteraction, UINode
+
+
+def extract_variables(
+    variable_map: Dict[str, str],
+    event: UserInteraction,
+    node: UINode
+) -> Dict[str, Any]:
+    """
+    Extract variables from matched event and node based on path expressions.
+    
+    Args:
+        variable_map: Dictionary mapping variable names to source paths
+                     (e.g., {"input_value": "event.value", "placeholder": "node.attributes.placeholder"})
+        event: The matched UserInteraction object
+        node: The matched UINode object
+    
+    Returns:
+        Dictionary mapping variable names to their resolved values.
+        Returns None for variables whose paths cannot be resolved.
+    
+    Examples:
+        >>> variable_map = {
+        ...     "input_value": "event.value",
+        ...     "placeholder": "node.attributes.placeholder",
+        ...     "node_text": "node.text"
+        ... }
+        >>> result = extract_variables(variable_map, event, node)
+        >>> # Returns: {"input_value": "cats", "placeholder": "Search...", "node_text": "Search field"}
+    """
+    result = {}
+    
+    for variable_name, path in variable_map.items():
+        resolved_value = _resolve_path(path, event, node)
+        result[variable_name] = resolved_value
+    
+    return result
+
+
+def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
+    """
+    Resolve a dotted path expression to extract a value from event or node.
+    
+    Args:
+        path: Dotted path expression (e.g., "event.value", "node.text", "node.attributes.placeholder")
+        event: The UserInteraction object
+        node: The UINode object
+    
+    Returns:
+        The resolved value, or None if the path cannot be resolved.
+    """
+    path_parts = path.split('.')
+    
+    if len(path_parts) < 2:
+        return None
+    
+    root = path_parts[0]
+    remaining_parts = path_parts[1:]
+    
+    # Determine the root object
+    if root == "event":
+        current_obj = event
+    elif root == "node":
+        current_obj = node
+    else:
+        return None
+    
+    # Traverse the path
+    for part in remaining_parts:
+        try:
+            if hasattr(current_obj, part):
+                current_obj = getattr(current_obj, part)
+            elif isinstance(current_obj, dict) and part in current_obj:
+                current_obj = current_obj[part]
+            else:
+                return None
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    return current_obj

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -84,7 +84,8 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
                 current_obj = current_obj[part]
             else:
                 return None
-        except (AttributeError, KeyError, TypeError):
+        except (AttributeError, KeyError, TypeError) as e:
+            logger.debug(f"Failed to resolve path '{path}' at part '{part}': {e}")
             return None
 
     return current_obj


### PR DESCRIPTION
**What it accomplishes:**
Extract values from matched `event` and `node` based on the `variables:` section of a rule.

**How to verify:**

* Unit tests validate extraction from:

  * `event.value`
  * `node.text`
  * `node.attributes.<key>`
* Fallback or error behavior clearly defined (e.g., missing fields = None)

Implements variable extraction functionality for the rule-based action matching system. The feature extracts values from matched event and node objects based on path expressions defined in the variables: section of rules.

Key changes:

* Adds a new variable_resolver.py module with path-based value extraction
* Implements comprehensive error handling for missing fields and invalid paths
* Provides extensive test coverage for various extraction scenarios
