### PR TITLE
Add CSS-style Child Node Query Support

### DIFF
--- a/test_gen/docs/rules_based_action_matching/prompt_plan.md
+++ b/test_gen/docs/rules_based_action_matching/prompt_plan.md
@@ -539,6 +539,84 @@ Support rules that extract values from descendant nodes via simple CSS selectors
 * Mock DOM structure in tests
 * Unit tests verify successful extraction or fallback behavior
 
+**Detailed Prompt:**
+
+You are enhancing the rule-based variable extraction system to support **simple CSS-style queries** on DOM nodes. This will allow rules to extract values from **child or descendant nodes** of a matched `UINode`.
+
+---
+
+#### ✅ Requirements
+
+##### 1. Implement a DOM query helper
+
+Create or update:
+📄 `test_gen/rule_engine/utils.py`
+
+Add a function:
+
+```python
+def query_node_text(
+    root_node: UINode,
+    all_nodes: List[UINode],
+    selector: str
+) -> Optional[str]:
+    ...
+```
+
+This should:
+
+* Interpret `selector` as a **simple CSS query** (e.g., `"div > span"`, `"label"`).
+* Search the subtree under `root_node` for the **first** matching descendant (by tag, optionally using `>` for direct children).
+* Return the `.text` of the matching `UINode`, or `None` if not found.
+
+💡 For v1:
+
+* Only support tag-based selectors (e.g., `"span"`, `"div > span"`)
+* Do **not** support classes, IDs, or attributes
+* Use `parent` references or build a map of children for tree traversal
+
+##### 2. Update variable extraction logic
+
+Update:
+📄 `test_gen/rule_engine/variable_resolver.py`
+
+Enhance `extract_variables(...)` to recognize expressions like:
+
+```yaml
+child_label: node.query("div > span").text
+```
+
+When this pattern is detected:
+
+* Extract the selector from the string
+* Use `query_node_text(...)` to find the matching node’s text
+* Return `None` if no match found
+
+---
+
+#### 🧪 Testing
+
+Create or extend test file:
+📄 `test_gen/rule_engine/tests/test_variable_extraction.py`
+
+Write unit tests that:
+
+* Construct a mock `UINode` tree with parent-child relationships
+* Test `query_node_text(...)` with:
+
+  * Simple tag match (e.g., `"span"`)
+  * Direct child match (e.g., `"div > span"`)
+  * No match (should return `None`)
+* Test `extract_variables(...)` with `node.query(...).text` expressions
+
+---
+
+#### ✅ Deliverables
+
+* Utility function: `query_node_text(...)` in `utils.py`
+* Updated logic in `extract_variables(...)` to support `.query(...)` access
+* Unit tests validating behavior and fallbacks
+
 ---
 
 ### **Step 8: Serialize and Save Matched Actions**

--- a/test_gen/rule_engine/tests/test_variable_extraction.py
+++ b/test_gen/rule_engine/tests/test_variable_extraction.py
@@ -2,12 +2,13 @@
 Unit tests for variable extraction functionality.
 
 Tests the extract_variables function with various scenarios including
-successful extractions, missing fields, and error handling.
+successful extractions, missing fields, error handling, and CSS-style queries.
 """
 
 import pytest
 
 from rule_engine.variable_resolver import extract_variables
+from rule_engine.utils import query_node_text
 from feature_extraction.models import UserInteraction, UINode
 
 
@@ -223,5 +224,215 @@ def test_mixed_valid_and_invalid_paths(mock_event, mock_node):
         "invalid_field": None,
         "valid_placeholder": "Search...",
         "invalid_attr": None,
+    }
+    assert result == expected
+
+
+@pytest.fixture(name="mock_dom_tree")
+def fixture_mock_dom_tree():
+    """Create a mock DOM tree for testing CSS-style queries."""
+    # Create nodes:
+    # root (div, id=1)
+    #   ├── header (div, id=2)
+    #   │   └── title (span, id=3, text="Page Title")
+    #   └── content (div, id=4)
+    #       ├── form (form, id=5)
+    #       │   ├── label (label, id=6, text="Search:")
+    #       │   └── input (input, id=7, text="")
+    #       └── footer (span, id=8, text="Footer text")
+    
+    root = UINode(id=1, tag="div", attributes={"class": "root"}, text="", parent=None)
+    header = UINode(id=2, tag="div", attributes={"class": "header"}, text="", parent=1)
+    title = UINode(id=3, tag="span", attributes={}, text="Page Title", parent=2)
+    content = UINode(id=4, tag="div", attributes={"class": "content"}, text="", parent=1)
+    form = UINode(id=5, tag="form", attributes={}, text="", parent=4)
+    label = UINode(id=6, tag="label", attributes={}, text="Search:", parent=5)
+    input_field = UINode(id=7, tag="input", attributes={"type": "text"}, text="", parent=5)
+    footer = UINode(id=8, tag="span", attributes={"class": "footer"}, text="Footer text", parent=4)
+    
+    all_nodes = [root, header, title, content, form, label, input_field, footer]
+    
+    return {"root": root, "all_nodes": all_nodes}
+
+
+def test_query_node_text_simple_tag_match(mock_dom_tree):
+    """Test query_node_text with simple tag selector."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    # Should find the first span (title)
+    result = query_node_text(root, all_nodes, "span")
+    assert result == "Page Title"
+
+
+def test_query_node_text_direct_child_selector(mock_dom_tree):
+    """Test query_node_text with direct child selector using '>'."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    # Should find span that is direct child of div > div (content > form doesn't have direct span child)
+    # But div (header) > span should match
+    result = query_node_text(root, all_nodes, "div > span")
+    assert result == "Page Title"  # First match is header > title
+
+
+def test_query_node_text_nested_selector(mock_dom_tree):
+    """Test query_node_text with nested selector."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    # Should find label that is child of form
+    result = query_node_text(root, all_nodes, "form > label")
+    assert result == "Search:"
+
+
+def test_query_node_text_no_match(mock_dom_tree):
+    """Test query_node_text when no nodes match the selector."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    # Should return None for non-existent tag
+    result = query_node_text(root, all_nodes, "button")
+    assert result is None
+
+
+def test_query_node_text_empty_selector(mock_dom_tree):
+    """Test query_node_text with empty selector."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    result = query_node_text(root, all_nodes, "")
+    assert result is None
+
+
+def test_query_node_text_invalid_selector(mock_dom_tree):
+    """Test query_node_text with invalid selector."""
+    root = mock_dom_tree["root"]
+    all_nodes = mock_dom_tree["all_nodes"]
+    
+    # Invalid selector with empty part after '>'
+    result = query_node_text(root, all_nodes, "div > ")
+    assert result is None
+
+
+def test_extract_variables_with_node_query(mock_event, mock_dom_tree):
+    """Test extract_variables with node.query().text expressions."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    # Use the form node as the root for this test
+    form_node = next(node for node in all_nodes if node.tag == "form")
+    
+    variable_map = {
+        "label_text": 'node.query("label").text',
+        "regular_field": "node.tag"
+    }
+    
+    result = extract_variables(variable_map, mock_event, form_node, all_nodes)
+    
+    expected = {
+        "label_text": "Search:",
+        "regular_field": "form"
+    }
+    assert result == expected
+
+
+def test_extract_variables_with_node_query_single_quotes(mock_event, mock_dom_tree):
+    """Test extract_variables with node.query().text using single quotes."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    root = mock_dom_tree["root"]
+    
+    variable_map = {
+        "page_title": "node.query('span').text"
+    }
+    
+    result = extract_variables(variable_map, mock_event, root, all_nodes)
+    
+    assert result == {"page_title": "Page Title"}
+
+
+def test_extract_variables_with_node_query_no_match(mock_event, mock_dom_tree):
+    """Test extract_variables with node.query().text when no nodes match."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    root = mock_dom_tree["root"]
+    
+    variable_map = {
+        "missing": 'node.query("button").text'
+    }
+    
+    result = extract_variables(variable_map, mock_event, root, all_nodes)
+    
+    assert result == {"missing": None}
+
+
+def test_extract_variables_with_node_query_complex_selector(mock_event, mock_dom_tree):
+    """Test extract_variables with complex CSS selector."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    root = mock_dom_tree["root"]
+    
+    variable_map = {
+        "form_label": 'node.query("form > label").text',
+        "header_title": 'node.query("div > span").text'
+    }
+    
+    result = extract_variables(variable_map, mock_event, root, all_nodes)
+    
+    expected = {
+        "form_label": "Search:",
+        "header_title": "Page Title"  # First match from header > title
+    }
+    assert result == expected
+
+
+def test_extract_variables_node_query_without_all_nodes(mock_event, mock_node):
+    """Test that node.query() expressions return None when all_nodes is not provided."""
+    variable_map = {
+        "child_text": 'node.query("span").text'
+    }
+    
+    # Call without all_nodes parameter
+    result = extract_variables(variable_map, mock_event, mock_node)
+    
+    assert result == {"child_text": None}
+
+
+def test_extract_variables_invalid_query_expression(mock_event, mock_dom_tree):
+    """Test extract_variables with invalid node.query() expression."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    root = mock_dom_tree["root"]
+    
+    variable_map = {
+        "invalid1": "node.query('span')",  # Missing .text
+        "invalid2": 'node.query("span").value',  # Wrong method
+        "invalid3": 'node.find("span").text'  # Wrong method name
+    }
+    
+    result = extract_variables(variable_map, mock_event, root, all_nodes)
+    
+    expected = {
+        "invalid1": None,
+        "invalid2": None,
+        "invalid3": None
+    }
+    assert result == expected
+
+
+def test_extract_variables_mixed_expressions(mock_event, mock_dom_tree):
+    """Test extract_variables with mix of regular paths and node.query() expressions."""
+    all_nodes = mock_dom_tree["all_nodes"]
+    root = mock_dom_tree["root"]
+    
+    variable_map = {
+        "event_action": "event.action",
+        "node_tag": "node.tag",
+        "query_result": 'node.query("span").text',
+        "missing_field": "event.nonexistent"
+    }
+    
+    result = extract_variables(variable_map, mock_event, root, all_nodes)
+    
+    expected = {
+        "event_action": "input",
+        "node_tag": "div",
+        "query_result": "Page Title",
+        "missing_field": None
     }
     assert result == expected

--- a/test_gen/rule_engine/tests/test_variable_extraction.py
+++ b/test_gen/rule_engine/tests/test_variable_extraction.py
@@ -240,18 +240,24 @@ def fixture_mock_dom_tree():
     #       │   ├── label (label, id=6, text="Search:")
     #       │   └── input (input, id=7, text="")
     #       └── footer (span, id=8, text="Footer text")
-    
+
     root = UINode(id=1, tag="div", attributes={"class": "root"}, text="", parent=None)
     header = UINode(id=2, tag="div", attributes={"class": "header"}, text="", parent=1)
     title = UINode(id=3, tag="span", attributes={}, text="Page Title", parent=2)
-    content = UINode(id=4, tag="div", attributes={"class": "content"}, text="", parent=1)
+    content = UINode(
+        id=4, tag="div", attributes={"class": "content"}, text="", parent=1
+    )
     form = UINode(id=5, tag="form", attributes={}, text="", parent=4)
     label = UINode(id=6, tag="label", attributes={}, text="Search:", parent=5)
-    input_field = UINode(id=7, tag="input", attributes={"type": "text"}, text="", parent=5)
-    footer = UINode(id=8, tag="span", attributes={"class": "footer"}, text="Footer text", parent=4)
-    
+    input_field = UINode(
+        id=7, tag="input", attributes={"type": "text"}, text="", parent=5
+    )
+    footer = UINode(
+        id=8, tag="span", attributes={"class": "footer"}, text="Footer text", parent=4
+    )
+
     all_nodes = [root, header, title, content, form, label, input_field, footer]
-    
+
     return {"root": root, "all_nodes": all_nodes}
 
 
@@ -259,7 +265,7 @@ def test_query_node_text_simple_tag_match(mock_dom_tree):
     """Test query_node_text with simple tag selector."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     # Should find the first span (title)
     result = query_node_text(root, all_nodes, "span")
     assert result == "Page Title"
@@ -269,7 +275,7 @@ def test_query_node_text_direct_child_selector(mock_dom_tree):
     """Test query_node_text with direct child selector using '>'."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     # Should find span that is direct child of div > div (content > form doesn't have direct span child)
     # But div (header) > span should match
     result = query_node_text(root, all_nodes, "div > span")
@@ -280,7 +286,7 @@ def test_query_node_text_nested_selector(mock_dom_tree):
     """Test query_node_text with nested selector."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     # Should find label that is child of form
     result = query_node_text(root, all_nodes, "form > label")
     assert result == "Search:"
@@ -290,7 +296,7 @@ def test_query_node_text_no_match(mock_dom_tree):
     """Test query_node_text when no nodes match the selector."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     # Should return None for non-existent tag
     result = query_node_text(root, all_nodes, "button")
     assert result is None
@@ -300,7 +306,7 @@ def test_query_node_text_empty_selector(mock_dom_tree):
     """Test query_node_text with empty selector."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     result = query_node_text(root, all_nodes, "")
     assert result is None
 
@@ -309,7 +315,7 @@ def test_query_node_text_invalid_selector(mock_dom_tree):
     """Test query_node_text with invalid selector."""
     root = mock_dom_tree["root"]
     all_nodes = mock_dom_tree["all_nodes"]
-    
+
     # Invalid selector with empty part after '>'
     result = query_node_text(root, all_nodes, "div > ")
     assert result is None
@@ -320,18 +326,15 @@ def test_extract_variables_with_node_query(mock_event, mock_dom_tree):
     all_nodes = mock_dom_tree["all_nodes"]
     # Use the form node as the root for this test
     form_node = next(node for node in all_nodes if node.tag == "form")
-    
+
     variable_map = {
         "label_text": 'node.query("label").text',
-        "regular_field": "node.tag"
+        "regular_field": "node.tag",
     }
-    
+
     result = extract_variables(variable_map, mock_event, form_node, all_nodes)
-    
-    expected = {
-        "label_text": "Search:",
-        "regular_field": "form"
-    }
+
+    expected = {"label_text": "Search:", "regular_field": "form"}
     assert result == expected
 
 
@@ -339,13 +342,11 @@ def test_extract_variables_with_node_query_single_quotes(mock_event, mock_dom_tr
     """Test extract_variables with node.query().text using single quotes."""
     all_nodes = mock_dom_tree["all_nodes"]
     root = mock_dom_tree["root"]
-    
-    variable_map = {
-        "page_title": "node.query('span').text"
-    }
-    
+
+    variable_map = {"page_title": "node.query('span').text"}
+
     result = extract_variables(variable_map, mock_event, root, all_nodes)
-    
+
     assert result == {"page_title": "Page Title"}
 
 
@@ -353,13 +354,11 @@ def test_extract_variables_with_node_query_no_match(mock_event, mock_dom_tree):
     """Test extract_variables with node.query().text when no nodes match."""
     all_nodes = mock_dom_tree["all_nodes"]
     root = mock_dom_tree["root"]
-    
-    variable_map = {
-        "missing": 'node.query("button").text'
-    }
-    
+
+    variable_map = {"missing": 'node.query("button").text'}
+
     result = extract_variables(variable_map, mock_event, root, all_nodes)
-    
+
     assert result == {"missing": None}
 
 
@@ -367,30 +366,28 @@ def test_extract_variables_with_node_query_complex_selector(mock_event, mock_dom
     """Test extract_variables with complex CSS selector."""
     all_nodes = mock_dom_tree["all_nodes"]
     root = mock_dom_tree["root"]
-    
+
     variable_map = {
         "form_label": 'node.query("form > label").text',
-        "header_title": 'node.query("div > span").text'
+        "header_title": 'node.query("div > span").text',
     }
-    
+
     result = extract_variables(variable_map, mock_event, root, all_nodes)
-    
+
     expected = {
         "form_label": "Search:",
-        "header_title": "Page Title"  # First match from header > title
+        "header_title": "Page Title",  # First match from header > title
     }
     assert result == expected
 
 
 def test_extract_variables_node_query_without_all_nodes(mock_event, mock_node):
     """Test that node.query() expressions return None when all_nodes is not provided."""
-    variable_map = {
-        "child_text": 'node.query("span").text'
-    }
-    
+    variable_map = {"child_text": 'node.query("span").text'}
+
     # Call without all_nodes parameter
     result = extract_variables(variable_map, mock_event, mock_node)
-    
+
     assert result == {"child_text": None}
 
 
@@ -398,20 +395,16 @@ def test_extract_variables_invalid_query_expression(mock_event, mock_dom_tree):
     """Test extract_variables with invalid node.query() expression."""
     all_nodes = mock_dom_tree["all_nodes"]
     root = mock_dom_tree["root"]
-    
+
     variable_map = {
         "invalid1": "node.query('span')",  # Missing .text
         "invalid2": 'node.query("span").value',  # Wrong method
-        "invalid3": 'node.find("span").text'  # Wrong method name
+        "invalid3": 'node.find("span").text',  # Wrong method name
     }
-    
+
     result = extract_variables(variable_map, mock_event, root, all_nodes)
-    
-    expected = {
-        "invalid1": None,
-        "invalid2": None,
-        "invalid3": None
-    }
+
+    expected = {"invalid1": None, "invalid2": None, "invalid3": None}
     assert result == expected
 
 
@@ -419,20 +412,20 @@ def test_extract_variables_mixed_expressions(mock_event, mock_dom_tree):
     """Test extract_variables with mix of regular paths and node.query() expressions."""
     all_nodes = mock_dom_tree["all_nodes"]
     root = mock_dom_tree["root"]
-    
+
     variable_map = {
         "event_action": "event.action",
         "node_tag": "node.tag",
         "query_result": 'node.query("span").text',
-        "missing_field": "event.nonexistent"
+        "missing_field": "event.nonexistent",
     }
-    
+
     result = extract_variables(variable_map, mock_event, root, all_nodes)
-    
+
     expected = {
         "event_action": "input",
         "node_tag": "div",
         "query_result": "Page Title",
-        "missing_field": None
+        "missing_field": None,
     }
     assert result == expected

--- a/test_gen/rule_engine/utils.py
+++ b/test_gen/rule_engine/utils.py
@@ -1,0 +1,113 @@
+"""
+Utility functions for rule-based variable extraction system.
+
+This module provides helper functions for DOM traversal and CSS-style
+node queries to support enhanced variable extraction.
+"""
+
+import re
+from typing import List, Optional
+from feature_extraction.models import UINode
+
+
+def query_node_text(
+    root_node: UINode,
+    all_nodes: List[UINode],
+    selector: str
+) -> Optional[str]:
+    """
+    Search for a descendant node using simple CSS-style selectors and return its text.
+    
+    This function supports basic tag-based selectors and direct child relationships
+    using the '>' operator. It searches the subtree under root_node for the first
+    matching descendant and returns the text content of that node.
+    
+    Args:
+        root_node: The UINode to search within
+        all_nodes: List of all UINodes to build the tree structure
+        selector: Simple CSS selector (e.g., "span", "div > span")
+                 Only supports tag names and direct child operator '>'
+    
+    Returns:
+        The text content of the first matching node, or None if no match found
+        
+    Examples:
+        >>> query_node_text(root, all_nodes, "span")  # Find any span descendant
+        >>> query_node_text(root, all_nodes, "div > span")  # Find span that is direct child of div
+    """
+    if not selector or not selector.strip():
+        return None
+        
+    # Parse selector - split on '>' to handle direct child relationships
+    selector_parts = [part.strip() for part in selector.split('>')]
+    if not selector_parts or not all(part for part in selector_parts):
+        return None
+    
+    # Build a map of node ID to UINode for efficient lookup
+    node_map = {node.id: node for node in all_nodes}
+    
+    # Build children map for tree traversal
+    children_map = {}
+    for node in all_nodes:
+        if node.parent is not None:
+            if node.parent not in children_map:
+                children_map[node.parent] = []
+            children_map[node.parent].append(node)
+    
+    # Start search from root_node
+    current_candidates = [root_node]
+    
+    # Process each selector part
+    for i, tag in enumerate(selector_parts):
+        if not current_candidates:
+            break
+            
+        next_candidates = []
+        
+        for candidate in current_candidates:
+            if i == 0:
+                # For the first selector part, search all descendants
+                descendants = _get_all_descendants(candidate, children_map)
+            else:
+                # For subsequent parts (after '>'), search only direct children
+                descendants = children_map.get(candidate.id, [])
+            
+            # Filter descendants by tag name
+            matching_descendants = [
+                desc for desc in descendants 
+                if desc.tag.lower() == tag.lower()
+            ]
+            
+            next_candidates.extend(matching_descendants)
+        
+        current_candidates = next_candidates
+    
+    # Return text of first match
+    if current_candidates:
+        return current_candidates[0].text
+    
+    return None
+
+
+def _get_all_descendants(node: UINode, children_map: dict) -> List[UINode]:
+    """
+    Get all descendant nodes (children, grandchildren, etc.) of a given node.
+    
+    Args:
+        node: The parent node to get descendants for
+        children_map: Dictionary mapping parent ID to list of child nodes
+        
+    Returns:
+        List of all descendant UINodes
+    """
+    descendants = []
+    
+    # Get direct children
+    direct_children = children_map.get(node.id, [])
+    descendants.extend(direct_children)
+    
+    # Recursively get descendants of each child
+    for child in direct_children:
+        descendants.extend(_get_all_descendants(child, children_map))
+    
+    return descendants

--- a/test_gen/rule_engine/utils.py
+++ b/test_gen/rule_engine/utils.py
@@ -11,41 +11,39 @@ from feature_extraction.models import UINode
 
 
 def query_node_text(
-    root_node: UINode,
-    all_nodes: List[UINode],
-    selector: str
+    root_node: UINode, all_nodes: List[UINode], selector: str
 ) -> Optional[str]:
     """
     Search for a descendant node using simple CSS-style selectors and return its text.
-    
+
     This function supports basic tag-based selectors and direct child relationships
     using the '>' operator. It searches the subtree under root_node for the first
     matching descendant and returns the text content of that node.
-    
+
     Args:
         root_node: The UINode to search within
         all_nodes: List of all UINodes to build the tree structure
         selector: Simple CSS selector (e.g., "span", "div > span")
                  Only supports tag names and direct child operator '>'
-    
+
     Returns:
         The text content of the first matching node, or None if no match found
-        
+
     Examples:
         >>> query_node_text(root, all_nodes, "span")  # Find any span descendant
         >>> query_node_text(root, all_nodes, "div > span")  # Find span that is direct child of div
     """
     if not selector or not selector.strip():
         return None
-        
+
     # Parse selector - split on '>' to handle direct child relationships
-    selector_parts = [part.strip() for part in selector.split('>')]
+    selector_parts = [part.strip() for part in selector.split(">")]
     if not selector_parts or not all(part for part in selector_parts):
         return None
-    
+
     # Build a map of node ID to UINode for efficient lookup
     node_map = {node.id: node for node in all_nodes}
-    
+
     # Build children map for tree traversal
     children_map = {}
     for node in all_nodes:
@@ -53,17 +51,17 @@ def query_node_text(
             if node.parent not in children_map:
                 children_map[node.parent] = []
             children_map[node.parent].append(node)
-    
+
     # Start search from root_node
     current_candidates = [root_node]
-    
+
     # Process each selector part
     for i, tag in enumerate(selector_parts):
         if not current_candidates:
             break
-            
+
         next_candidates = []
-        
+
         for candidate in current_candidates:
             if i == 0:
                 # For the first selector part, search all descendants
@@ -71,43 +69,42 @@ def query_node_text(
             else:
                 # For subsequent parts (after '>'), search only direct children
                 descendants = children_map.get(candidate.id, [])
-            
+
             # Filter descendants by tag name
             matching_descendants = [
-                desc for desc in descendants 
-                if desc.tag.lower() == tag.lower()
+                desc for desc in descendants if desc.tag.lower() == tag.lower()
             ]
-            
+
             next_candidates.extend(matching_descendants)
-        
+
         current_candidates = next_candidates
-    
+
     # Return text of first match
     if current_candidates:
         return current_candidates[0].text
-    
+
     return None
 
 
 def _get_all_descendants(node: UINode, children_map: dict) -> List[UINode]:
     """
     Get all descendant nodes (children, grandchildren, etc.) of a given node.
-    
+
     Args:
         node: The parent node to get descendants for
         children_map: Dictionary mapping parent ID to list of child nodes
-        
+
     Returns:
         List of all descendant UINodes
     """
     descendants = []
-    
+
     # Get direct children
     direct_children = children_map.get(node.id, [])
     descendants.extend(direct_children)
-    
+
     # Recursively get descendants of each child
     for child in direct_children:
         descendants.extend(_get_all_descendants(child, children_map))
-    
+
     return descendants

--- a/test_gen/rule_engine/utils.py
+++ b/test_gen/rule_engine/utils.py
@@ -5,7 +5,6 @@ This module provides helper functions for DOM traversal and CSS-style
 node queries to support enhanced variable extraction.
 """
 
-import re
 from typing import List, Optional
 from feature_extraction.models import UINode
 
@@ -40,9 +39,6 @@ def query_node_text(
     selector_parts = [part.strip() for part in selector.split(">")]
     if not selector_parts or not all(part for part in selector_parts):
         return None
-
-    # Build a map of node ID to UINode for efficient lookup
-    node_map = {node.id: node for node in all_nodes}
 
     # Build children map for tree traversal
     children_map = {}

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -7,7 +7,7 @@ events and UINode objects based on path expressions defined in rules.
 
 import logging
 import re
-from typing import Dict, Any, List
+from typing import Any, Dict, List, Optional
 from feature_extraction.models import UserInteraction, UINode
 from .utils import query_node_text
 
@@ -42,7 +42,12 @@ def extract_variables(
         ...     "child_label": "node.query('div > span').text"
         ... }
         >>> result = extract_variables(variable_map, event, node, all_nodes)
-        >>> # Returns: {"input_value": "cats", "placeholder": "Search...", "node_text": "Search field", "child_label": "Label text"}
+        >>> # Returns: {
+        ...     "input_value": "cats",
+        ...     "placeholder": "Search...",
+        ...     "node_text": "Search field",
+        ...     "child_label": "Label text"
+        ... }
     """
     result = {}
 
@@ -149,8 +154,4 @@ def _resolve_query_expression(
 
     selector = match.group(1)
 
-    try:
-        return query_node_text(node, all_nodes, selector)
-    except Exception as e:
-        logger.debug("Failed to resolve query expression '%s': %s", path, e)
-        return None
+    return query_node_text(node, all_nodes, selector)

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -6,14 +6,16 @@ events and UINode objects based on path expressions defined in rules.
 """
 
 import logging
-from typing import Dict, Any
+import re
+from typing import Dict, Any, List
 from feature_extraction.models import UserInteraction, UINode
+from .utils import query_node_text
 
 logger = logging.getLogger(__name__)
 
 
 def extract_variables(
-    variable_map: Dict[str, str], event: UserInteraction, node: UINode
+    variable_map: Dict[str, str], event: UserInteraction, node: UINode, all_nodes: List[UINode] = None
 ) -> Dict[str, Any]:
     """
     Extract variables from matched event and node based on path expressions.
@@ -23,6 +25,7 @@ def extract_variables(
                      (e.g., {"input_value": "event.value", "placeholder": "node.attributes.placeholder"})
         event: The matched UserInteraction object
         node: The matched UINode object
+        all_nodes: Optional list of all UINodes for CSS-style queries (required for node.query() expressions)
 
     Returns:
         Dictionary mapping variable names to their resolved values.
@@ -32,15 +35,20 @@ def extract_variables(
         >>> variable_map = {
         ...     "input_value": "event.value",
         ...     "placeholder": "node.attributes.placeholder",
-        ...     "node_text": "node.text"
+        ...     "node_text": "node.text",
+        ...     "child_label": "node.query('div > span').text"
         ... }
-        >>> result = extract_variables(variable_map, event, node)
-        >>> # Returns: {"input_value": "cats", "placeholder": "Search...", "node_text": "Search field"}
+        >>> result = extract_variables(variable_map, event, node, all_nodes)
+        >>> # Returns: {"input_value": "cats", "placeholder": "Search...", "node_text": "Search field", "child_label": "Label text"}
     """
     result = {}
 
     for variable_name, path in variable_map.items():
-        resolved_value = _resolve_path(path, event, node)
+        # Check if this is a node.query().text expression
+        if _is_query_expression(path):
+            resolved_value = _resolve_query_expression(path, node, all_nodes)
+        else:
+            resolved_value = _resolve_path(path, event, node)
         result[variable_name] = resolved_value
 
     return result
@@ -91,3 +99,51 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
             return None
 
     return current_obj
+
+
+def _is_query_expression(path: str) -> bool:
+    """
+    Check if a path expression is a node.query().text pattern.
+    
+    Args:
+        path: The path expression to check
+        
+    Returns:
+        True if this is a node.query().text expression, False otherwise
+    """
+    # Pattern: node.query("selector").text or node.query('selector').text
+    pattern = r'^node\.query\(["\']([^"\']+)["\']\)\.text$'
+    return bool(re.match(pattern, path))
+
+
+def _resolve_query_expression(path: str, node: UINode, all_nodes: List[UINode]) -> Optional[str]:
+    """
+    Resolve a node.query().text expression by extracting the selector and querying the DOM.
+    
+    Args:
+        path: The query expression (e.g., 'node.query("div > span").text')
+        node: The root node to search from
+        all_nodes: List of all nodes for building the tree structure
+        
+    Returns:
+        The text content of the matching node, or None if no match found or invalid expression
+    """
+    if not all_nodes:
+        logger.debug("Cannot resolve query expression '%s': all_nodes is required", path)
+        return None
+    
+    # Extract the selector from the expression
+    pattern = r'^node\.query\(["\']([^"\']+)["\']\)\.text$'
+    match = re.match(pattern, path)
+    
+    if not match:
+        logger.debug("Invalid query expression format: '%s'", path)
+        return None
+    
+    selector = match.group(1)
+    
+    try:
+        return query_node_text(node, all_nodes, selector)
+    except Exception as e:
+        logger.debug("Failed to resolve query expression '%s': %s", path, e)
+        return None

--- a/test_gen/rule_engine/variable_resolver.py
+++ b/test_gen/rule_engine/variable_resolver.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def extract_variables(
-    variable_map: Dict[str, str], event: UserInteraction, node: UINode, all_nodes: List[UINode] = None
+    variable_map: Dict[str, str],
+    event: UserInteraction,
+    node: UINode,
+    all_nodes: List[UINode] = None,
 ) -> Dict[str, Any]:
     """
     Extract variables from matched event and node based on path expressions.
@@ -104,10 +107,10 @@ def _resolve_path(path: str, event: UserInteraction, node: UINode) -> Any:
 def _is_query_expression(path: str) -> bool:
     """
     Check if a path expression is a node.query().text pattern.
-    
+
     Args:
         path: The path expression to check
-        
+
     Returns:
         True if this is a node.query().text expression, False otherwise
     """
@@ -116,32 +119,36 @@ def _is_query_expression(path: str) -> bool:
     return bool(re.match(pattern, path))
 
 
-def _resolve_query_expression(path: str, node: UINode, all_nodes: List[UINode]) -> Optional[str]:
+def _resolve_query_expression(
+    path: str, node: UINode, all_nodes: List[UINode]
+) -> Optional[str]:
     """
     Resolve a node.query().text expression by extracting the selector and querying the DOM.
-    
+
     Args:
         path: The query expression (e.g., 'node.query("div > span").text')
         node: The root node to search from
         all_nodes: List of all nodes for building the tree structure
-        
+
     Returns:
         The text content of the matching node, or None if no match found or invalid expression
     """
     if not all_nodes:
-        logger.debug("Cannot resolve query expression '%s': all_nodes is required", path)
+        logger.debug(
+            "Cannot resolve query expression '%s': all_nodes is required", path
+        )
         return None
-    
+
     # Extract the selector from the expression
     pattern = r'^node\.query\(["\']([^"\']+)["\']\)\.text$'
     match = re.match(pattern, path)
-    
+
     if not match:
         logger.debug("Invalid query expression format: '%s'", path)
         return None
-    
+
     selector = match.group(1)
-    
+
     try:
         return query_node_text(node, all_nodes, selector)
     except Exception as e:


### PR DESCRIPTION
**What it accomplishes:**
Support rules that extract values from descendant nodes via simple CSS selectors (e.g., `node.query("div > span").text`)

**How to verify:**

* Introduce helper for DOM traversal
* Mock DOM structure in tests
* Unit tests verify successful extraction or fallback behavior
