### PR TITLE
Serialize and Save Matched Actions

### DIFF
--- a/.claude/commands/implement_step.md
+++ b/.claude/commands/implement_step.md
@@ -7,4 +7,6 @@ $ARGUMENTS
 
 --
 
+Please feel free to make changes to existing code.  When you're done, please make a commit using git including all changes.  Please use the content of your final "deliverables completed" summary message as the commit message.  Please don't try running the tests added, I will run the test manually.
+
 Please implement the step described in the input section above.

--- a/test_gen/docs/rules_based_action_matching/prompt_plan.md
+++ b/test_gen/docs/rules_based_action_matching/prompt_plan.md
@@ -630,6 +630,67 @@ Write detected actions from a chunk to disk as JSON in `test_gen/data/action_map
 * File content matches expected structure
 * Integration test: process test chunk → check saved file
 
+**Detailed prompt:**
+
+You are working on a rule-based engine that detects user actions from rrweb session chunks. Your task is to **serialize detected actions to disk as JSON**, using a filename based on the chunk ID.
+
+---
+
+#### ✅ Requirements
+
+Create or update the following module:
+📄 `test_gen/rule_engine/matcher.py`
+
+Add a function:
+
+```python
+def save_detected_actions(
+    actions: List[DetectedAction],
+    chunk_id: str,
+    output_dir: Union[str, Path] = "test_gen/data/action_mappings"
+) -> None:
+    ...
+```
+
+This function should:
+
+* Create the output directory if it doesn’t exist
+* Serialize `actions` to JSON using `chunk_id` as the filename:
+  → `test_gen/data/action_mappings/{chunk_id}.json`
+* Convert all fields of `DetectedAction` into JSON-safe values:
+
+  * Use `asdict()` or manual serialization if needed
+  * `UINode` (if present) should also be serialized as a dict
+
+---
+
+#### 🧪 Testing
+
+Create or extend:
+📄 `test_gen/rule_engine/tests/test_matcher.py`
+
+Write an integration-style test that:
+
+* Creates a fake chunk and rules
+* Runs `detect_actions_in_chunk(...)`
+* Saves the result with `save_detected_actions(...)`
+* Loads the written file and asserts:
+
+  * File exists at correct location
+  * JSON content includes expected action fields (e.g., `action_id`, `timestamp`, `variables`)
+
+Also test:
+
+* Saving with no detected actions (should still create a valid empty list file)
+
+---
+
+#### ✅ Deliverables
+
+* Function `save_detected_actions(...)` in `matcher.py`
+* JSON file written to `test_gen/data/action_mappings/{chunk_id}.json`
+* Unit test verifying file structure and output correctness
+
 ---
 
 ### **Step 9: Add CLI Entry Point**

--- a/test_gen/rule_engine/matcher.py
+++ b/test_gen/rule_engine/matcher.py
@@ -172,7 +172,7 @@ def detect_actions_in_chunk(
 def save_detected_actions(
     actions: List[DetectedAction],
     chunk_id: str,
-    output_dir: Union[str, Path] = "test_gen/data/action_mappings"
+    output_dir: Union[str, Path] = "test_gen/data/action_mappings",
 ) -> None:
     """
     Serialize detected actions to disk as JSON using chunk_id as filename.
@@ -187,26 +187,26 @@ def save_detected_actions(
     """
     # Convert output_dir to Path object
     output_path = Path(output_dir)
-    
+
     # Create the output directory if it doesn't exist
     output_path.mkdir(parents=True, exist_ok=True)
-    
+
     # Convert DetectedAction objects to JSON-serializable dicts
     serializable_actions = []
     for action in actions:
         action_dict = asdict(action)
-        
+
         # Convert UINode to dict if present (asdict handles this automatically)
         # but ensure it's JSON-serializable
-        if action_dict.get('target_element') is not None:
+        if action_dict.get("target_element") is not None:
             # asdict already converts dataclasses to dicts recursively
             pass
-        
+
         serializable_actions.append(action_dict)
-    
+
     # Define the output file path
     output_file = output_path / f"{chunk_id}.json"
-    
+
     # Write to JSON file
-    with open(output_file, 'w', encoding='utf-8') as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(serializable_actions, f, indent=2, ensure_ascii=False)

--- a/test_gen/rule_engine/matcher.py
+++ b/test_gen/rule_engine/matcher.py
@@ -5,7 +5,10 @@ This module implements the core matching logic to determine if a UserInteraction
 and UINode pair matches the conditions specified in a Rule.
 """
 
-from typing import Dict, Any, Optional, List
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Union
 
 from feature_extraction.models import UserInteraction, UINode
 
@@ -164,3 +167,46 @@ def detect_actions_in_chunk(
                 detected_actions.append(detected_action)
 
     return detected_actions
+
+
+def save_detected_actions(
+    actions: List[DetectedAction],
+    chunk_id: str,
+    output_dir: Union[str, Path] = "test_gen/data/action_mappings"
+) -> None:
+    """
+    Serialize detected actions to disk as JSON using chunk_id as filename.
+
+    Args:
+        actions: List of DetectedAction objects to serialize
+        chunk_id: ID to use for the filename
+        output_dir: Directory to save the file to
+
+    The function creates the output directory if it doesn't exist and saves
+    the actions as JSON to {output_dir}/{chunk_id}.json.
+    """
+    # Convert output_dir to Path object
+    output_path = Path(output_dir)
+    
+    # Create the output directory if it doesn't exist
+    output_path.mkdir(parents=True, exist_ok=True)
+    
+    # Convert DetectedAction objects to JSON-serializable dicts
+    serializable_actions = []
+    for action in actions:
+        action_dict = asdict(action)
+        
+        # Convert UINode to dict if present (asdict handles this automatically)
+        # but ensure it's JSON-serializable
+        if action_dict.get('target_element') is not None:
+            # asdict already converts dataclasses to dicts recursively
+            pass
+        
+        serializable_actions.append(action_dict)
+    
+    # Define the output file path
+    output_file = output_path / f"{chunk_id}.json"
+    
+    # Write to JSON file
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(serializable_actions, f, indent=2, ensure_ascii=False)

--- a/test_gen/rule_engine/matcher.py
+++ b/test_gen/rule_engine/matcher.py
@@ -196,12 +196,6 @@ def save_detected_actions(
     for action in actions:
         action_dict = asdict(action)
 
-        # Convert UINode to dict if present (asdict handles this automatically)
-        # but ensure it's JSON-serializable
-        if action_dict.get("target_element") is not None:
-            # asdict already converts dataclasses to dicts recursively
-            pass
-
         serializable_actions.append(action_dict)
 
     # Define the output file path

--- a/test_gen/rule_engine/tests/test_matcher.py
+++ b/test_gen/rule_engine/tests/test_matcher.py
@@ -692,7 +692,7 @@ class TestSaveDetectedActions:
             assert expected_file.exists()
 
             # Load and verify JSON content
-            with open(expected_file, "r") as f:
+            with open(expected_file, "r", encoding="utf-8") as f:
                 saved_data = json.load(f)
 
             assert len(saved_data) == 1
@@ -732,7 +732,7 @@ class TestSaveDetectedActions:
             assert expected_file.exists()
 
             # Load and verify JSON content is empty list
-            with open(expected_file, "r") as f:
+            with open(expected_file, "r", encoding="utf-8") as f:
                 saved_data = json.load(f)
 
             assert saved_data == []
@@ -780,7 +780,7 @@ class TestSaveDetectedActions:
             expected_file = Path(temp_dir) / f"{chunk_id}.json"
             assert expected_file.exists()
 
-            with open(expected_file, "r") as f:
+            with open(expected_file, "r", encoding="utf-8") as f:
                 saved_data = json.load(f)
 
             assert len(saved_data) == 1

--- a/test_gen/rule_engine/tests/test_matcher.py
+++ b/test_gen/rule_engine/tests/test_matcher.py
@@ -660,9 +660,7 @@ class TestSaveDetectedActions:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test actions
             rule = create_test_rule(
-                rule_id="test_rule_1",
-                action_id="search_query",
-                confidence=0.9
+                rule_id="test_rule_1", action_id="search_query", confidence=0.9
             )
             rule.variables = {"search_term": "event.value"}
 
@@ -670,14 +668,14 @@ class TestSaveDetectedActions:
                 action="input",
                 target_id=123,
                 value="machine learning",
-                timestamp=1642500000000
+                timestamp=1642500000000,
             )
 
             node = create_test_node(
                 node_id=123,
                 tag="input",
                 attributes={"type": "search", "placeholder": "Search..."},
-                text=""
+                text="",
             )
 
             # Create a detected action using apply_rule_to_event_and_node
@@ -694,28 +692,31 @@ class TestSaveDetectedActions:
             assert expected_file.exists()
 
             # Load and verify JSON content
-            with open(expected_file, 'r') as f:
+            with open(expected_file, "r") as f:
                 saved_data = json.load(f)
 
             assert len(saved_data) == 1
             action_data = saved_data[0]
-            
+
             # Verify all DetectedAction fields are present
-            assert action_data['action_id'] == "search_query"
-            assert action_data['timestamp'] == 1642500000000
-            assert action_data['confidence'] == 0.9
-            assert action_data['rule_id'] == "test_rule_1"
-            assert action_data['variables'] == {"search_term": "machine learning"}
-            assert action_data['related_events'] == [0]
-            
+            assert action_data["action_id"] == "search_query"
+            assert action_data["timestamp"] == 1642500000000
+            assert action_data["confidence"] == 0.9
+            assert action_data["rule_id"] == "test_rule_1"
+            assert action_data["variables"] == {"search_term": "machine learning"}
+            assert action_data["related_events"] == [0]
+
             # Verify target_element (UINode) is properly serialized
-            assert action_data['target_element'] is not None
-            target_element = action_data['target_element']
-            assert target_element['id'] == 123
-            assert target_element['tag'] == "input"
-            assert target_element['attributes'] == {"type": "search", "placeholder": "Search..."}
-            assert target_element['text'] == ""
-            assert target_element['parent'] is None
+            assert action_data["target_element"] is not None
+            target_element = action_data["target_element"]
+            assert target_element["id"] == 123
+            assert target_element["tag"] == "input"
+            assert target_element["attributes"] == {
+                "type": "search",
+                "placeholder": "Search...",
+            }
+            assert target_element["text"] == ""
+            assert target_element["parent"] is None
 
     def test_save_empty_actions_list(self):
         """Test saving empty actions list creates valid empty JSON file."""
@@ -731,7 +732,7 @@ class TestSaveDetectedActions:
             assert expected_file.exists()
 
             # Load and verify JSON content is empty list
-            with open(expected_file, 'r') as f:
+            with open(expected_file, "r") as f:
                 saved_data = json.load(f)
 
             assert saved_data == []
@@ -745,7 +746,7 @@ class TestSaveDetectedActions:
                 match_event={"action": "input"},
                 match_node={"tag": "input", "attributes": {"type": "search"}},
                 action_id="search_query",
-                confidence=0.9
+                confidence=0.9,
             )
             rule.variables = {"search_term": "event.value"}
 
@@ -753,13 +754,11 @@ class TestSaveDetectedActions:
                 action="input",
                 target_id=123,
                 value="integration test",
-                timestamp=1642500000000
+                timestamp=1642500000000,
             )
 
             node = create_test_node(
-                node_id=123,
-                tag="input",
-                attributes={"type": "search", "name": "query"}
+                node_id=123, tag="input", attributes={"type": "search", "name": "query"}
             )
 
             chunk = {
@@ -781,11 +780,11 @@ class TestSaveDetectedActions:
             expected_file = Path(temp_dir) / f"{chunk_id}.json"
             assert expected_file.exists()
 
-            with open(expected_file, 'r') as f:
+            with open(expected_file, "r") as f:
                 saved_data = json.load(f)
 
             assert len(saved_data) == 1
             action_data = saved_data[0]
-            assert action_data['action_id'] == "search_query"
-            assert action_data['variables'] == {"search_term": "integration test"}
-            assert action_data['rule_id'] == "integration_rule"
+            assert action_data["action_id"] == "search_query"
+            assert action_data["variables"] == {"search_term": "integration test"}
+            assert action_data["rule_id"] == "integration_rule"

--- a/test_gen/rule_engine/tests/test_matcher.py
+++ b/test_gen/rule_engine/tests/test_matcher.py
@@ -5,12 +5,16 @@ This module tests the core matching logic that determines if UserInteraction
 and UINode pairs match Rule conditions.
 """
 
+import json
+import tempfile
+from pathlib import Path
 from typing import Dict, Any
 
 from rule_engine.matcher import (
     rule_matches_event_node,
     apply_rule_to_event_and_node,
     detect_actions_in_chunk,
+    save_detected_actions,
 )
 from rule_engine.models import Rule
 from feature_extraction.models import UserInteraction, UINode
@@ -646,3 +650,142 @@ class TestDetectActionsInChunk:
 
         # Verify empty result
         assert len(result) == 0
+
+
+class TestSaveDetectedActions:
+    """Tests for save_detected_actions function."""
+
+    def test_save_actions_with_data(self):
+        """Test saving detected actions to JSON file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test actions
+            rule = create_test_rule(
+                rule_id="test_rule_1",
+                action_id="search_query",
+                confidence=0.9
+            )
+            rule.variables = {"search_term": "event.value"}
+
+            event = create_test_event(
+                action="input",
+                target_id=123,
+                value="machine learning",
+                timestamp=1642500000000
+            )
+
+            node = create_test_node(
+                node_id=123,
+                tag="input",
+                attributes={"type": "search", "placeholder": "Search..."},
+                text=""
+            )
+
+            # Create a detected action using apply_rule_to_event_and_node
+            detected_action = apply_rule_to_event_and_node(rule, event, node, 0)
+            actions = [detected_action]
+
+            chunk_id = "test_chunk_123"
+
+            # Save actions
+            save_detected_actions(actions, chunk_id, temp_dir)
+
+            # Verify file was created
+            expected_file = Path(temp_dir) / f"{chunk_id}.json"
+            assert expected_file.exists()
+
+            # Load and verify JSON content
+            with open(expected_file, 'r') as f:
+                saved_data = json.load(f)
+
+            assert len(saved_data) == 1
+            action_data = saved_data[0]
+            
+            # Verify all DetectedAction fields are present
+            assert action_data['action_id'] == "search_query"
+            assert action_data['timestamp'] == 1642500000000
+            assert action_data['confidence'] == 0.9
+            assert action_data['rule_id'] == "test_rule_1"
+            assert action_data['variables'] == {"search_term": "machine learning"}
+            assert action_data['related_events'] == [0]
+            
+            # Verify target_element (UINode) is properly serialized
+            assert action_data['target_element'] is not None
+            target_element = action_data['target_element']
+            assert target_element['id'] == 123
+            assert target_element['tag'] == "input"
+            assert target_element['attributes'] == {"type": "search", "placeholder": "Search..."}
+            assert target_element['text'] == ""
+            assert target_element['parent'] is None
+
+    def test_save_empty_actions_list(self):
+        """Test saving empty actions list creates valid empty JSON file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chunk_id = "empty_chunk_456"
+            actions = []
+
+            # Save empty actions
+            save_detected_actions(actions, chunk_id, temp_dir)
+
+            # Verify file was created
+            expected_file = Path(temp_dir) / f"{chunk_id}.json"
+            assert expected_file.exists()
+
+            # Load and verify JSON content is empty list
+            with open(expected_file, 'r') as f:
+                saved_data = json.load(f)
+
+            assert saved_data == []
+
+    def test_integration_detect_and_save_actions(self):
+        """Integration test: detect actions in chunk and save to file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create rule and chunk data
+            rule = create_test_rule(
+                rule_id="integration_rule",
+                match_event={"action": "input"},
+                match_node={"tag": "input", "attributes": {"type": "search"}},
+                action_id="search_query",
+                confidence=0.9
+            )
+            rule.variables = {"search_term": "event.value"}
+
+            interaction = create_test_event(
+                action="input",
+                target_id=123,
+                value="integration test",
+                timestamp=1642500000000
+            )
+
+            node = create_test_node(
+                node_id=123,
+                tag="input",
+                attributes={"type": "search", "name": "query"}
+            )
+
+            chunk = {
+                "features": {
+                    "user_interactions": [interaction],
+                    "ui_nodes": [node],
+                }
+            }
+
+            # Detect actions
+            detected_actions = detect_actions_in_chunk(chunk, [rule])
+            assert len(detected_actions) == 1
+
+            # Save detected actions
+            chunk_id = "integration_test_chunk"
+            save_detected_actions(detected_actions, chunk_id, temp_dir)
+
+            # Verify saved file
+            expected_file = Path(temp_dir) / f"{chunk_id}.json"
+            assert expected_file.exists()
+
+            with open(expected_file, 'r') as f:
+                saved_data = json.load(f)
+
+            assert len(saved_data) == 1
+            action_data = saved_data[0]
+            assert action_data['action_id'] == "search_query"
+            assert action_data['variables'] == {"search_term": "integration test"}
+            assert action_data['rule_id'] == "integration_rule"


### PR DESCRIPTION
**What it accomplishes:**
Write detected actions from a chunk to disk as JSON in `test_gen/data/action_mappings/`, keyed by `chunk_id`.

**How to verify:**

* CLI or function call can process a chunk and write a JSON file
* File content matches expected structure
* Integration test: process test chunk → check saved file

--
Implements functionality to serialize and save detected actions from chunks to disk as JSON files. The main purpose is to persist action detection results for later use, with files saved in test_gen/data/action_mappings/ using the chunk ID as the filename.

* Adds save_detected_actions() function to serialize DetectedAction objects to JSON
* Creates comprehensive test suite covering normal operation, empty actions, and integration scenarios
* Updates documentation with detailed implementation requirements
