### PR TITLE
Enable PKCE for Google OAuth login flow

### DIFF
--- a/server/chalk/todos/oauth.py
+++ b/server/chalk/todos/oauth.py
@@ -21,18 +21,20 @@ logger = logging.getLogger(__name__)
 
 def get_authorization_url(host):
     """
-    Create an authorization URL to redirect a user to for OAuth login
+    Create an authorization URL to redirect a user to for OAuth login.
+    Returns (url, state, code_verifier) — the caller must persist code_verifier
+    keyed by state so it can be supplied to fetch_token in the callback.
     """
     flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-        CLIENT_SECRETS_FILE, scopes=SCOPES, autogenerate_code_verifier=False)
+        CLIENT_SECRETS_FILE, scopes=SCOPES)
     flow.redirect_uri = _get_redirect_uri(host)
 
     # NOTE using offline access to get a refresh token
     # is needed for integration test auth workflows.
     # It's printed below in _get_authorized_session
-    # authorization_url, _ = flow.authorization_url(access_type='offline')
-    authorization_url, _ = flow.authorization_url()
-    return authorization_url
+    # authorization_url, state = flow.authorization_url(access_type='offline')
+    authorization_url, state = flow.authorization_url()
+    return authorization_url, state, flow.code_verifier
 
 
 class OAuthBackend(BaseBackend):
@@ -47,7 +49,8 @@ class OAuthBackend(BaseBackend):
 
         if 'state' in request.GET:
             session = _get_authorized_session(token, request.GET['state'],
-                                              request.get_host())
+                                              request.get_host(),
+                                              kwargs.get('pkce_verifier'))
         elif 'ci_refresh' in request.GET:
             client_secrets_obj = _get_clients_secret_obj()
             session = AuthorizedSession(
@@ -110,10 +113,10 @@ def _get_email_from_session(session):
     return profile_info['email']
 
 
-def _get_authorized_session(token, state, host):
+def _get_authorized_session(token, state, host, code_verifier=None):
     flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
         CLIENT_SECRETS_FILE, scopes=SCOPES, state=state,
-        autogenerate_code_verifier=False)
+        autogenerate_code_verifier=False, code_verifier=code_verifier)
     flow.redirect_uri = _get_redirect_uri(host)
 
     flow.fetch_token(code=token)

--- a/server/chalk/todos/views.py
+++ b/server/chalk/todos/views.py
@@ -31,7 +31,9 @@ def auth(request):
     """
     API endpoint that redirects a user to Google for login
     """
-    return redirect(get_authorization_url(request.get_host()))
+    url, state, code_verifier = get_authorization_url(request.get_host())
+    request.session[f'pkce_{state}'] = code_verifier
+    return redirect(url)
 
 
 @api_view(['GET'])
@@ -39,7 +41,12 @@ def auth_callback(request):
     """
     API endpoint that handles the Google OAuth callback to log the user in
     """
-    user = authenticate(request, token=request.GET['code'])
+    state = request.GET.get('state')
+    pkce_verifier = None
+    if state:
+        pkce_verifier = request.session.pop(f'pkce_{state}', None)
+    user = authenticate(request, token=request.GET['code'],
+                        pkce_verifier=pkce_verifier)
     if user is not None:
         login(request, user)
 


### PR DESCRIPTION
## Summary

- `google-auth-oauthlib` 1.3.1 made `autogenerate_code_verifier=True` the default, causing login failures (`invalid_grant: Missing code verifier`) because the authorization and token-exchange steps use separate `Flow` instances and the verifier was lost between them
- Persist the `code_verifier` in the Django session (keyed by OAuth `state`) during the auth redirect, then retrieve and pass it to the second flow's `fetch_token` call
- Keying by `state` rather than a fixed session key handles concurrent logins from multiple browser tabs correctly

## Test plan

- [ ] Log in via Google OAuth and verify redirect to `/` succeeds
- [ ] Open two login tabs simultaneously and confirm both complete independently
- [ ] Existing test suite passes (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)