### PR TITLE
Frontend: Refactor Snooze filtering to match the Unlabeled virtual-label pattern

### DIFF
--- a/ui/js/src/__snapshots__/App.stories.tsx.snap
+++ b/ui/js/src/__snapshots__/App.stories.tsx.snap
@@ -199,6 +199,29 @@ exports[`App Layout DefaultLayout smoke-test 1`] = `
               </div>
             </button>
           </div>
+          <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+               data-testid="chip-container"
+               style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+          >
+            <button role="button"
+                    tabindex="0"
+                    class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                    data-testid="chip"
+                    type="button"
+                    style="border-radius: 8px;"
+            >
+              <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                   style="padding-right: 0px;"
+              >
+                <div dir="auto"
+                     class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                     style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                >
+                  Snoozed
+                </div>
+              </div>
+            </button>
+          </div>
           <div class="css-g5y9jx r-16y2uox">
           </div>
           <div dir="auto"
@@ -262,6 +285,126 @@ exports[`App Layout DefaultLayout smoke-test 1`] = `
                   󰄱
                 </span>
               </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div aria-live="polite"
+           class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+           data-testid="modal"
+      >
+        <button aria-label="Close modal"
+                role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+                data-testid="modal-backdrop"
+                type="button"
+                style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+        >
+        </button>
+        <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+             data-testid="modal-wrapper"
+             style="margin-top: 0px; margin-bottom: 0px;"
+        >
+          <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+               data-testid="modal-surface"
+               style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+          >
+            <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+                 data-testid="snooze-menu"
+            >
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Tomorrow
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      This Saturday
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Week
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Month
+                    </div>
+                  </div>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -470,6 +613,29 @@ exports[`App Layout LabelPickerLayout smoke-test 1`] = `
               </div>
             </button>
           </div>
+          <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+               data-testid="chip-container"
+               style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+          >
+            <button role="button"
+                    tabindex="0"
+                    class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                    data-testid="chip"
+                    type="button"
+                    style="border-radius: 8px;"
+            >
+              <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                   style="padding-right: 0px;"
+              >
+                <div dir="auto"
+                     class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                     style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                >
+                  Snoozed
+                </div>
+              </div>
+            </button>
+          </div>
           <div class="css-g5y9jx r-16y2uox">
           </div>
           <div dir="auto"
@@ -625,6 +791,26 @@ exports[`App Layout LabelPickerLayout smoke-test 1`] = `
                                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                   >
                                     󰜢
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
                                   </div>
                                 </button>
                               </div>
@@ -1064,6 +1250,26 @@ exports[`App Layout LabelPickerLayout smoke-test 1`] = `
                                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                   >
                                     󰜢
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
                                   </div>
                                 </button>
                               </div>
@@ -1885,6 +2091,126 @@ exports[`App Layout LabelPickerLayout smoke-test 1`] = `
           </div>
         </div>
       </div>
+      <div aria-live="polite"
+           class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+           data-testid="modal"
+      >
+        <button aria-label="Close modal"
+                role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+                data-testid="modal-backdrop"
+                type="button"
+                style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+        >
+        </button>
+        <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+             data-testid="modal-wrapper"
+             style="margin-top: 0px; margin-bottom: 0px;"
+        >
+          <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+               data-testid="modal-surface"
+               style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+          >
+            <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+                 data-testid="snooze-menu"
+            >
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Tomorrow
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      This Saturday
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Week
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Month
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -2089,6 +2415,29 @@ exports[`App Layout ListTodosLayout smoke-test 1`] = `
               </div>
             </button>
           </div>
+          <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+               data-testid="chip-container"
+               style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+          >
+            <button role="button"
+                    tabindex="0"
+                    class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                    data-testid="chip"
+                    type="button"
+                    style="border-radius: 8px;"
+            >
+              <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                   style="padding-right: 0px;"
+              >
+                <div dir="auto"
+                     class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                     style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                >
+                  Snoozed
+                </div>
+              </div>
+            </button>
+          </div>
           <div class="css-g5y9jx r-16y2uox">
           </div>
           <div dir="auto"
@@ -2244,6 +2593,26 @@ exports[`App Layout ListTodosLayout smoke-test 1`] = `
                                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                   >
                                     󰜢
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
                                   </div>
                                 </button>
                               </div>
@@ -2683,6 +3052,26 @@ exports[`App Layout ListTodosLayout smoke-test 1`] = `
                                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                   >
                                     󰜢
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
                                   </div>
                                 </button>
                               </div>
@@ -3047,6 +3436,126 @@ exports[`App Layout ListTodosLayout smoke-test 1`] = `
           </div>
         </div>
       </div>
+      <div aria-live="polite"
+           class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+           data-testid="modal"
+      >
+        <button aria-label="Close modal"
+                role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+                data-testid="modal-backdrop"
+                type="button"
+                style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+        >
+        </button>
+        <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+             data-testid="modal-wrapper"
+             style="margin-top: 0px; margin-bottom: 0px;"
+        >
+          <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+               data-testid="modal-surface"
+               style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+          >
+            <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+                 data-testid="snooze-menu"
+            >
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Tomorrow
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      This Saturday
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Week
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Month
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -3251,6 +3760,29 @@ exports[`App Layout NotificationLayout smoke-test 1`] = `
               </div>
             </button>
           </div>
+          <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+               data-testid="chip-container"
+               style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+          >
+            <button role="button"
+                    tabindex="0"
+                    class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                    data-testid="chip"
+                    type="button"
+                    style="border-radius: 8px;"
+            >
+              <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                   style="padding-right: 0px;"
+              >
+                <div dir="auto"
+                     class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                     style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                >
+                  Snoozed
+                </div>
+              </div>
+            </button>
+          </div>
           <div class="css-g5y9jx r-16y2uox">
           </div>
           <div dir="auto"
@@ -3406,6 +3938,26 @@ exports[`App Layout NotificationLayout smoke-test 1`] = `
                                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                   >
                                     󰜢
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
                                   </div>
                                 </button>
                               </div>
@@ -3849,6 +4401,26 @@ exports[`App Layout NotificationLayout smoke-test 1`] = `
                                 </button>
                               </div>
                               <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                   data-testid="snooze-todo-container"
+                                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                              >
+                                <button role="button"
+                                        tabindex="0"
+                                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                        data-testid="snooze-todo"
+                                        type="button"
+                                >
+                                  <div dir="auto"
+                                       role="img"
+                                       tabindex="-1"
+                                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                  >
+                                    󰀤
+                                  </div>
+                                </button>
+                              </div>
+                              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                    data-testid="delete-todo-container"
                                    style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                               >
@@ -4204,6 +4776,126 @@ exports[`App Layout NotificationLayout smoke-test 1`] = `
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div aria-live="polite"
+           class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+           data-testid="modal"
+      >
+        <button aria-label="Close modal"
+                role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+                data-testid="modal-backdrop"
+                type="button"
+                style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+        >
+        </button>
+        <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+             data-testid="modal-wrapper"
+             style="margin-top: 0px; margin-bottom: 0px;"
+        >
+          <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+               data-testid="modal-surface"
+               style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+          >
+            <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+                 data-testid="snooze-menu"
+            >
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Tomorrow
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      This Saturday
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Week
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Month
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>

--- a/ui/js/src/components/WorkContextFilter.tsx
+++ b/ui/js/src/components/WorkContextFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { FILTER_STATUS } from '../redux/types';
-import { setSnoozedOnly, setWorkContext } from '../redux/reducers';
+import { setWorkContext } from '../redux/reducers';
 import { useAppDispatch } from '../hooks/hooks';
 import { workContexts } from '../redux/workspaceSlice';
 import LabelChip from './LabelChip';
@@ -32,10 +32,6 @@ const WorkContextFilter: React.FC<Props> = function (props: Props) {
     dispatch(setWorkContext(workContext));
   }, []);
 
-  const setSnoozedOnlyCb = useCallback((_label: string) => {
-    dispatch(setSnoozedOnly(true));
-  }, []);
-
   const chips = Object.keys(workContexts).map((workContext) => (
     <LabelChip
       display={workContexts[workContext].displayName}
@@ -50,12 +46,6 @@ const WorkContextFilter: React.FC<Props> = function (props: Props) {
   return (
     <View style={styles.filterView} testID="work-context-filter">
       {chips}
-      <LabelChip
-        key="snoozed"
-        label="Snoozed"
-        onPress={setSnoozedOnlyCb}
-        status={activeWorkContext === 'snoozed' ? FILTER_STATUS.Active : undefined}
-      />
       <View style={styles.spacer} />
       <FilterViewControls
         isFiltered={isFiltered}

--- a/ui/js/src/components/__snapshots__/SnoozeMenu.stories.tsx.snap
+++ b/ui/js/src/components/__snapshots__/SnoozeMenu.stories.tsx.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Snooze Menu DefaultSnoozeMenu smoke-test 1`] = `
+<div class="css-g5y9jx r-13awgt0">
+  <div class="css-g5y9jx r-13awgt0 r-12vffkv">
+    <div class="css-g5y9jx r-gjda0u r-oejqat">
+      <div aria-live="polite"
+           class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+           data-testid="modal"
+      >
+        <button aria-label="Close modal"
+                role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+                data-testid="modal-backdrop"
+                type="button"
+                style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+        >
+        </button>
+        <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+             data-testid="modal-wrapper"
+             style="margin-top: 0px; margin-bottom: 0px;"
+        >
+          <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+               data-testid="modal-surface"
+               style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+          >
+            <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+                 data-testid="snooze-menu"
+            >
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Tomorrow
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      This Saturday
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Week
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                   data-testid="chip-container"
+                   style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                        data-testid="chip"
+                        type="button"
+                        style="border-radius: 8px;"
+                >
+                  <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                       style="padding-right: 0px;"
+                  >
+                    <div dir="auto"
+                         class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                         style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                    >
+                      Next Month
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snooze Menu HiddenSnoozeMenu smoke-test 1`] = `
+<div class="css-g5y9jx r-13awgt0">
+  <div class="css-g5y9jx r-13awgt0 r-12vffkv">
+    <div class="css-g5y9jx r-gjda0u r-oejqat">
+    </div>
+  </div>
+</div>
+`;

--- a/ui/js/src/components/__snapshots__/TodoItem.stories.tsx.snap
+++ b/ui/js/src/components/__snapshots__/TodoItem.stories.tsx.snap
@@ -81,6 +81,26 @@ exports[`Todo Item CheckedTodo smoke-test 1`] = `
                 </button>
               </div>
               <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                   data-testid="snooze-todo-container"
+                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                        data-testid="snooze-todo"
+                        type="button"
+                >
+                  <div dir="auto"
+                       role="img"
+                       tabindex="-1"
+                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                  >
+                    󰀤
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                    data-testid="delete-todo-container"
                    style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
               >
@@ -265,6 +285,26 @@ exports[`Todo Item DefaultTodo smoke-test 1`] = `
                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                   >
                     󰜢
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                   data-testid="snooze-todo-container"
+                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                        data-testid="snooze-todo"
+                        type="button"
+                >
+                  <div dir="auto"
+                       role="img"
+                       tabindex="-1"
+                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                  >
+                    󰀤
                   </div>
                 </button>
               </div>
@@ -638,6 +678,26 @@ exports[`Todo Item NoLabelsTodo smoke-test 1`] = `
                 </button>
               </div>
               <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                   data-testid="snooze-todo-container"
+                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                        data-testid="snooze-todo"
+                        type="button"
+                >
+                  <div dir="auto"
+                       role="img"
+                       tabindex="-1"
+                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                  >
+                    󰀤
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                    data-testid="delete-todo-container"
                    style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
               >
@@ -743,6 +803,26 @@ exports[`Todo Item WrappedLabelsTodo smoke-test 1`] = `
                        style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                   >
                     󰜢
+                  </div>
+                </button>
+              </div>
+              <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                   data-testid="snooze-todo-container"
+                   style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+              >
+                <button role="button"
+                        tabindex="0"
+                        class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                        data-testid="snooze-todo"
+                        type="button"
+                >
+                  <div dir="auto"
+                       role="img"
+                       tabindex="-1"
+                       class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                       style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                  >
+                    󰀤
                   </div>
                 </button>
               </div>

--- a/ui/js/src/components/__snapshots__/TodoList.stories.tsx.snap
+++ b/ui/js/src/components/__snapshots__/TodoList.stories.tsx.snap
@@ -196,6 +196,29 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
             </div>
           </button>
         </div>
+        <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+             data-testid="chip-container"
+             style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+        >
+          <button role="button"
+                  tabindex="0"
+                  class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                  data-testid="chip"
+                  type="button"
+                  style="border-radius: 8px;"
+          >
+            <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                 style="padding-right: 0px;"
+            >
+              <div dir="auto"
+                   class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                   style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+              >
+                Snoozed
+              </div>
+            </div>
+          </button>
+        </div>
         <div class="css-g5y9jx r-16y2uox">
         </div>
         <div dir="auto"
@@ -351,6 +374,26 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -615,6 +658,26 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -1140,6 +1203,26 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                               </button>
                             </div>
                             <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                  data-testid="delete-todo-container"
                                  style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                             >
@@ -1400,6 +1483,26 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -1668,6 +1771,26 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                               </button>
                             </div>
                             <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                  data-testid="delete-todo-container"
                                  style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                             >
@@ -1848,6 +1971,126 @@ exports[`Todo List DefaultTodoList smoke-test 1`] = `
                   </div>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div aria-live="polite"
+         class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+         data-testid="modal"
+    >
+      <button aria-label="Close modal"
+              role="button"
+              tabindex="0"
+              class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+              data-testid="modal-backdrop"
+              type="button"
+              style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+      >
+      </button>
+      <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+           data-testid="modal-wrapper"
+           style="margin-top: 0px; margin-bottom: 0px;"
+      >
+        <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+             data-testid="modal-surface"
+             style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+        >
+          <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+               data-testid="snooze-menu"
+          >
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Tomorrow
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    This Saturday
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Week
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Month
+                  </div>
+                </div>
+              </button>
             </div>
           </div>
         </div>
@@ -2053,6 +2296,29 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
             </div>
           </button>
         </div>
+        <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+             data-testid="chip-container"
+             style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+        >
+          <button role="button"
+                  tabindex="0"
+                  class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                  data-testid="chip"
+                  type="button"
+                  style="border-radius: 8px;"
+          >
+            <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                 style="padding-right: 0px;"
+            >
+              <div dir="auto"
+                   class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                   style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+              >
+                Snoozed
+              </div>
+            </div>
+          </button>
+        </div>
         <div class="css-g5y9jx r-16y2uox">
         </div>
         <div dir="auto"
@@ -2208,6 +2474,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -2476,6 +2762,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                               </button>
                             </div>
                             <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                  data-testid="delete-todo-container"
                                  style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                             >
@@ -2736,6 +3042,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -3004,6 +3330,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                               </button>
                             </div>
                             <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                  data-testid="delete-todo-container"
                                  style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                             >
@@ -3268,6 +3614,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                               </button>
                             </div>
                             <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
                                  data-testid="delete-todo-container"
                                  style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
                             >
@@ -3528,6 +3894,26 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -4104,6 +4490,126 @@ exports[`Todo List LabelPickerOverlay smoke-test 1`] = `
         </div>
       </div>
     </div>
+    <div aria-live="polite"
+         class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+         data-testid="modal"
+    >
+      <button aria-label="Close modal"
+              role="button"
+              tabindex="0"
+              class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+              data-testid="modal-backdrop"
+              type="button"
+              style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+      >
+      </button>
+      <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+           data-testid="modal-wrapper"
+           style="margin-top: 0px; margin-bottom: 0px;"
+      >
+        <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+             data-testid="modal-surface"
+             style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+        >
+          <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+               data-testid="snooze-menu"
+          >
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Tomorrow
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    This Saturday
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Week
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Month
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -4304,6 +4810,29 @@ exports[`Todo List LoadingIndicator smoke-test 1`] = `
             </div>
           </button>
         </div>
+        <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+             data-testid="chip-container"
+             style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+        >
+          <button role="button"
+                  tabindex="0"
+                  class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                  data-testid="chip"
+                  type="button"
+                  style="border-radius: 8px;"
+          >
+            <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                 style="padding-right: 0px;"
+            >
+              <div dir="auto"
+                   class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                   style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+              >
+                Snoozed
+              </div>
+            </div>
+          </button>
+        </div>
         <div class="css-g5y9jx r-16y2uox">
         </div>
         <div dir="auto"
@@ -4459,6 +4988,26 @@ exports[`Todo List LoadingIndicator smoke-test 1`] = `
                                      style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
                                 >
                                   󰜢
+                                </div>
+                              </button>
+                            </div>
+                            <div class="css-g5y9jx r-1udh08x r-crgep1 r-105ug2t"
+                                 data-testid="snooze-todo-container"
+                                 style="background-color: rgba(0, 0, 0, 0); width: 36px; height: 36px; border-width: 0px; border-radius: 18px; border-color: rgb(121, 116, 126);"
+                            >
+                              <button role="button"
+                                      tabindex="0"
+                                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-1awozwy r-16y2uox r-1777fci"
+                                      data-testid="snooze-todo"
+                                      type="button"
+                              >
+                                <div dir="auto"
+                                     role="img"
+                                     tabindex="-1"
+                                     class="css-146c3p1 r-1niwhzg r-lrvibr r-633pao"
+                                     style="font-size: 20px; color: rgb(163, 213, 255); transform: scaleX(1); line-height: 20px; font-family: material-community; font-weight: normal; font-style: normal;"
+                                >
+                                  󰀤
                                 </div>
                               </button>
                             </div>
@@ -4700,6 +5249,126 @@ exports[`Todo List LoadingIndicator smoke-test 1`] = `
         </div>
       </div>
       <div class="css-g5y9jx r-16y2uox">
+      </div>
+    </div>
+    <div aria-live="polite"
+         class="css-g5y9jx r-1p0dtai r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-105ug2t"
+         data-testid="modal"
+    >
+      <button aria-label="Close modal"
+              role="button"
+              tabindex="0"
+              class="css-g5y9jx r-1loqt21 r-1otgn73 r-13awgt0"
+              data-testid="modal-backdrop"
+              type="button"
+              style="background-color: rgba(50, 47, 55, 0.4); opacity: 1;"
+      >
+      </button>
+      <div class="css-g5y9jx r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-12vffkv"
+           data-testid="modal-wrapper"
+           style="margin-top: 0px; margin-bottom: 0px;"
+      >
+        <div class="css-g5y9jx r-1niwhzg r-1777fci r-1jj8364 r-lchren r-6e0ovw r-105ug2t"
+             data-testid="modal-surface"
+             style="box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 3px; opacity: 1;"
+        >
+          <div class="css-g5y9jx r-hr69ez r-18u37iz r-1w6e6rj"
+               data-testid="snooze-menu"
+          >
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Tomorrow
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    This Saturday
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Week
+                  </div>
+                </div>
+              </button>
+            </div>
+            <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+                 data-testid="chip-container"
+                 style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+            >
+              <button role="button"
+                      tabindex="0"
+                      class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                      data-testid="chip"
+                      type="button"
+                      style="border-radius: 8px;"
+              >
+                <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+                     style="padding-right: 0px;"
+                >
+                  <div dir="auto"
+                       class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                       style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+                  >
+                    Next Month
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/ui/js/src/components/__snapshots__/WorkContextFilter.stories.tsx.snap
+++ b/ui/js/src/components/__snapshots__/WorkContextFilter.stories.tsx.snap
@@ -177,6 +177,29 @@ exports[`Work Context Filter ActiveWorkContextFilter smoke-test 1`] = `
           </div>
         </button>
       </div>
+      <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+           data-testid="chip-container"
+           style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+      >
+        <button role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                data-testid="chip"
+                type="button"
+                style="border-radius: 8px;"
+        >
+          <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+               style="padding-right: 0px;"
+          >
+            <div dir="auto"
+                 class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                 style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+            >
+              Snoozed
+            </div>
+          </div>
+        </button>
+      </div>
       <div class="css-g5y9jx r-16y2uox">
       </div>
       <div dir="auto"
@@ -389,6 +412,29 @@ exports[`Work Context Filter DefaultWorkContextFilter smoke-test 1`] = `
                  style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
             >
               Chalk Planning
+            </div>
+          </div>
+        </button>
+      </div>
+      <div class="css-g5y9jx r-1phboty r-18u37iz r-rs99b7 r-78d8zt r-1bq2mok r-105ug2t"
+           data-testid="chip-container"
+           style="border-color: rgba(0, 0, 0, 0); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px;"
+      >
+        <button role="button"
+                tabindex="0"
+                class="css-g5y9jx r-1otgn73 r-1loqt21 r-bnwqim r-ctqt5z r-1udh08x r-13qz1uu"
+                data-testid="chip"
+                type="button"
+                style="border-radius: 8px;"
+        >
+          <div class="css-g5y9jx r-1awozwy r-18u37iz r-bnwqim r-gy4na3"
+               style="padding-right: 0px;"
+          >
+            <div dir="auto"
+                 class="css-146c3p1 r-dnmrzs r-1udh08x r-1udbk01 r-3s2u2q r-1iln25a r-fdjqy7 r-ws14 r-9iso6 r-1x2decy r-15zivkp r-1jkjb r-1kb76zh r-14gqq1x r-lrvibr"
+                 style="direction: ltr; color: rgb(29, 25, 43); letter-spacing: 0.1px; font-weight: 500; line-height: 20px; font-size: 14px;"
+            >
+              Snoozed
             </div>
           </div>
         </button>

--- a/ui/js/src/hooks/useUrlSync.ts
+++ b/ui/js/src/hooks/useUrlSync.ts
@@ -59,7 +59,7 @@ export function useUrlSync() {
     // Note this assumes that the Inbox is the default state and should be updated if that ever changes
     if (
       _.isEqual(activeLabels, ['Unlabeled']) &&
-      invertedLabels.length === 0 &&
+      _.isEqual(invertedLabels, ['snoozed']) &&
       !showCompletedTodos
     ) {
       window.history.replaceState({}, '', window.location.pathname);

--- a/ui/js/src/redux/reducers.ts
+++ b/ui/js/src/redux/reducers.ts
@@ -126,7 +126,12 @@ export const completeAuthentication =
       if (response.status !== 200) {
         const responseText = await response.text();
         const message = `Login failed with status: ${response.status} ${response.statusText}\n${responseText}`;
-        dispatch(notificationsSlice.actions.addNotification({ text: message, type: 'default' }));
+        dispatch(
+          notificationsSlice.actions.addNotification({
+            text: message,
+            type: 'default',
+          }),
+        );
         throw new Error(message);
       }
 
@@ -196,7 +201,6 @@ export const dismissNotification =
   notificationsSlice.actions.dismissNotification;
 export const setEditTodoId = workspaceSlice.actions.setEditTodoId;
 export const setLabelTodoId = workspaceSlice.actions.setLabelTodoId;
-export const setSnoozedOnly = workspaceSlice.actions.setSnoozedOnly;
 export const setSnoozeTodoId = workspaceSlice.actions.setSnoozeTodoId;
 export const setWorkContext = workspaceSlice.actions.setWorkContext;
 export const setFilters = workspaceSlice.actions.setFilters;

--- a/ui/js/src/redux/todosApiSlice.test.ts
+++ b/ui/js/src/redux/todosApiSlice.test.ts
@@ -92,6 +92,29 @@ describe('createTodo', function () {
     expect(fetchMock).toBeDone();
   });
 
+  it('should create todo with empty labels when the Snoozed work context is active', async function () {
+    const stubDescription = 'test snoozed context todo';
+    const stubTodo = getStubTodo({ description: stubDescription, labels: [] });
+    fetchMock.postOnce(getTodosApi(), {
+      body: stubTodo,
+    });
+
+    const store = setupStore({
+      workspace: {
+        filterLabels: {
+          snoozed: FILTER_STATUS.Active,
+        },
+      },
+    });
+    await store.dispatch(createTodo(stubDescription));
+
+    // Verify the POST request did not attach a literal "snoozed" label
+    verifyRequestIncludesLabels([]);
+
+    // Verify we make the server request
+    expect(fetchMock).toBeDone();
+  });
+
   it('should create todo with only active labels, excluding inverted', async function () {
     const stubDescription = 'test todo with mixed filters';
     const stubTodo = getStubTodo({

--- a/ui/js/src/redux/types.ts
+++ b/ui/js/src/redux/types.ts
@@ -81,7 +81,6 @@ export interface WorkspaceState {
   loggedIn: boolean;
   showCompletedTodos: boolean;
   showLabelFilter: boolean;
-  snoozedOnly: boolean;
   snoozeTodoId: number | null;
 }
 

--- a/ui/js/src/redux/workspaceSlice.test.ts
+++ b/ui/js/src/redux/workspaceSlice.test.ts
@@ -1,6 +1,6 @@
 import '../__mocks__/matchMediaMock';
 import { FILTER_STATUS } from './types';
-import { workspaceSlice } from './workspaceSlice';
+import { workContexts, workspaceSlice } from './workspaceSlice';
 
 describe('workspace reducer', function () {
   it('should return the initial state', function () {
@@ -9,12 +9,12 @@ describe('workspace reducer', function () {
       editTodoId: null,
       filterLabels: {
         Unlabeled: FILTER_STATUS.Active,
+        snoozed: FILTER_STATUS.Inverted,
       },
       labelTodoId: null,
       loggedIn: false,
       showCompletedTodos: false,
       showLabelFilter: false,
-      snoozedOnly: false,
       snoozeTodoId: null,
     });
   });
@@ -162,6 +162,7 @@ describe('workspace reducer', function () {
       expect(result).toEqual({
         filterLabels: {
           Unlabeled: FILTER_STATUS.Active,
+          snoozed: FILTER_STATUS.Inverted,
         },
       });
     });
@@ -185,38 +186,34 @@ describe('workspace reducer', function () {
       });
     });
   });
-  describe('workspace/setSnoozedOnly', function () {
-    it('should enable snoozed-only mode and clear filterLabels', function () {
-      const result = workspaceSlice.reducer(
-        {
-          snoozedOnly: false,
-          filterLabels: { Unlabeled: FILTER_STATUS.Active },
+  describe('workContexts', function () {
+    it('should define a virtual Snoozed work context', function () {
+      expect(workContexts.snoozed).toEqual({
+        displayName: 'Snoozed',
+        labels: {
+          snoozed: FILTER_STATUS.Active,
         },
-        {
-          type: 'workspace/setSnoozedOnly',
-          payload: true,
-        },
-      );
-      expect(result).toEqual({
-        snoozedOnly: true,
-        filterLabels: {},
       });
     });
 
-    it('should disable snoozed-only mode without changing filterLabels', function () {
-      const result = workspaceSlice.reducer(
-        {
-          snoozedOnly: true,
-          filterLabels: {},
+    it('should invert both backlog and snoozed by default for non-Inbox contexts', function () {
+      expect(workContexts.urgent).toEqual({
+        displayName: 'Urgent',
+        labels: {
+          urgent: FILTER_STATUS.Active,
+          backlog: FILTER_STATUS.Inverted,
+          snoozed: FILTER_STATUS.Inverted,
         },
-        {
-          type: 'workspace/setSnoozedOnly',
-          payload: false,
+      });
+    });
+
+    it('should keep Inbox backlog-inclusive while still excluding snoozed todos', function () {
+      expect(workContexts.inbox).toEqual({
+        displayName: 'Inbox',
+        labels: {
+          Unlabeled: FILTER_STATUS.Active,
+          snoozed: FILTER_STATUS.Inverted,
         },
-      );
-      expect(result).toEqual({
-        snoozedOnly: false,
-        filterLabels: {},
       });
     });
   });

--- a/ui/js/src/redux/workspaceSlice.ts
+++ b/ui/js/src/redux/workspaceSlice.ts
@@ -10,54 +10,64 @@ import {
 
 // TODO (jordan) Improve to support or'd label groups
 // Will be useful for adding Chalk + vague to Chalk Planning
+
+// Backlogged and snoozed todos are hidden from work contexts by default;
+// merge this in for any context that shouldn't override that default.
+const withDefaultInversions = (labels: FilterState): FilterState => ({
+  backlog: FILTER_STATUS.Inverted,
+  snoozed: FILTER_STATUS.Inverted,
+  ...labels,
+});
+
 export const workContexts: { [key: string]: WorkContext } = {
   inbox: {
     displayName: 'Inbox',
     labels: {
       Unlabeled: FILTER_STATUS.Active,
+      snoozed: FILTER_STATUS.Inverted,
     },
   },
   urgent: {
     displayName: 'Urgent',
-    labels: {
+    labels: withDefaultInversions({
       urgent: FILTER_STATUS.Active,
-      backlog: FILTER_STATUS.Inverted,
-    },
+    }),
   },
   quickFixes: {
     displayName: 'Quick Fixes',
-    labels: {
+    labels: withDefaultInversions({
       '5 minutes': FILTER_STATUS.Active,
-      backlog: FILTER_STATUS.Inverted,
-    },
+    }),
   },
   upNext: {
     displayName: 'Up Next',
-    labels: {
-      backlog: FILTER_STATUS.Inverted,
+    labels: withDefaultInversions({
       'up next': FILTER_STATUS.Active,
-    },
+    }),
   },
   work: {
     displayName: 'Work',
-    labels: {
-      backlog: FILTER_STATUS.Inverted,
+    labels: withDefaultInversions({
       work: FILTER_STATUS.Active,
-    },
+    }),
   },
   shopping: {
     displayName: 'Shopping',
-    labels: {
-      backlog: FILTER_STATUS.Inverted,
+    labels: withDefaultInversions({
       Shopping: FILTER_STATUS.Active,
-    },
+    }),
   },
   chalkPlanning: {
     displayName: 'Chalk Planning',
-    labels: {
+    labels: withDefaultInversions({
       Chalk: FILTER_STATUS.Active,
-      backlog: FILTER_STATUS.Inverted,
       vague: FILTER_STATUS.Active,
+    }),
+  },
+  snoozed: {
+    displayName: 'Snoozed',
+    labels: {
+      snoozed: FILTER_STATUS.Active,
     },
   },
 };
@@ -67,12 +77,12 @@ const initialState: WorkspaceState = {
   editTodoId: null,
   filterLabels: {
     Unlabeled: FILTER_STATUS.Active,
+    snoozed: FILTER_STATUS.Inverted,
   },
   labelTodoId: null,
   loggedIn: Platform.OS === 'web',
   showCompletedTodos: false,
   showLabelFilter: false,
-  snoozedOnly: false,
   snoozeTodoId: null,
 };
 export const workspaceSlice = createSlice({
@@ -93,7 +103,6 @@ export const workspaceSlice = createSlice({
       const workContext = workContexts[action.payload];
       if (workContext) {
         state.filterLabels = Object.assign({}, workContext.labels);
-        state.snoozedOnly = false;
       }
     },
     setFilters: (state, action) => {
@@ -140,12 +149,6 @@ export const workspaceSlice = createSlice({
     },
     toggleShowLabelFilter: (state) => {
       state.showLabelFilter = !state.showLabelFilter;
-    },
-    setSnoozedOnly: (state, action) => {
-      state.snoozedOnly = action.payload;
-      if (action.payload) {
-        state.filterLabels = {};
-      }
     },
     setSnoozeTodoId: (state, action) => {
       state.snoozeTodoId = action.payload;

--- a/ui/js/src/selectors.test.ts
+++ b/ui/js/src/selectors.test.ts
@@ -29,7 +29,6 @@ function selectFilteredTodosHelper(activeLabels, invertedLabels, todos) {
   return {
     workspace: {
       filterLabels,
-      snoozedOnly: false,
     },
     shortcuts: {
       operations: [],
@@ -187,10 +186,10 @@ describe('selectFilteredTodos', function () {
     expect(result).toMatchSnapshot();
   });
 
-  it('should filter out todos with snoozed_until set to a future time', function () {
+  it('should filter out todos with snoozed_until set to a future time when snoozed is inverted', function () {
     jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     const futureDate = new Date(Date.now() + 86400000).toISOString();
-    const state = selectFilteredTodosHelper(['Unlabeled'], [], {});
+    const state = selectFilteredTodosHelper(['Unlabeled'], ['snoozed'], {});
     state.todosApi.entries = [
       { id: 1, description: 'normal todo', labels: [], snoozed_until: null },
       {
@@ -206,10 +205,10 @@ describe('selectFilteredTodos', function () {
     jest.useRealTimers();
   });
 
-  it('should include todos with snoozed_until set to a past time', function () {
+  it('should include todos with snoozed_until set to a past time when snoozed is inverted', function () {
     jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     const pastDate = new Date(Date.now() - 86400000).toISOString();
-    const state = selectFilteredTodosHelper(['Unlabeled'], [], {});
+    const state = selectFilteredTodosHelper(['Unlabeled'], ['snoozed'], {});
     state.todosApi.entries = [
       {
         id: 1,
@@ -224,13 +223,12 @@ describe('selectFilteredTodos', function () {
     jest.useRealTimers();
   });
 
-  it('should return only currently-snoozed todos sorted by snoozed_until when snoozedOnly is true', function () {
+  it('should return only currently-snoozed todos sorted by snoozed_until when the snoozed filter is active', function () {
     jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     const sooner = new Date(Date.now() + 86400000).toISOString();
     const later = new Date(Date.now() + 2 * 86400000).toISOString();
     const past = new Date(Date.now() - 86400000).toISOString();
-    const state = selectFilteredTodosHelper([], [], {});
-    state.workspace.snoozedOnly = true;
+    const state = selectFilteredTodosHelper(['snoozed'], [], {});
     state.todosApi.entries = [
       { id: 1, description: 'later snoozed', labels: [], snoozed_until: later },
       { id: 2, description: 'normal todo', labels: [], snoozed_until: null },
@@ -248,6 +246,36 @@ describe('selectFilteredTodos', function () {
       'sooner snoozed',
       'later snoozed',
     ]);
+    jest.useRealTimers();
+  });
+
+  it('should combine the snoozed filter with a real label filter', function () {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+    const state = selectFilteredTodosHelper(['snoozed', 'urgent'], [], {});
+    state.todosApi.entries = [
+      {
+        id: 1,
+        description: 'snoozed and urgent',
+        labels: ['urgent'],
+        snoozed_until: futureDate,
+      },
+      {
+        id: 2,
+        description: 'snoozed but not urgent',
+        labels: [],
+        snoozed_until: futureDate,
+      },
+      {
+        id: 3,
+        description: 'urgent but not snoozed',
+        labels: ['urgent'],
+        snoozed_until: null,
+      },
+    ];
+
+    const result = selectFilteredTodos(state);
+    expect(result.map((t) => t.description)).toEqual(['snoozed and urgent']);
     jest.useRealTimers();
   });
 });
@@ -326,11 +354,12 @@ describe('selectSelectedPickerLabels', function () {
 });
 
 describe('selectActiveWorkContext', function () {
-  it('should return snoozed when snoozedOnly is true', function () {
+  it('should return snoozed when the snoozed filter is active', function () {
     const state = {
       workspace: {
-        filterLabels: {},
-        snoozedOnly: true,
+        filterLabels: {
+          snoozed: FILTER_STATUS.Active,
+        },
       },
     };
 
@@ -344,9 +373,9 @@ describe('selectActiveWorkContext', function () {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
           backlog: FILTER_STATUS.Inverted,
+          snoozed: FILTER_STATUS.Inverted,
           vague: FILTER_STATUS.Active,
         },
-        snoozedOnly: false,
       },
     };
 
@@ -360,10 +389,10 @@ describe('selectActiveWorkContext', function () {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
           backlog: FILTER_STATUS.Inverted,
+          snoozed: FILTER_STATUS.Inverted,
           vague: FILTER_STATUS.Active,
           Home: FILTER_STATUS.Active,
         },
-        snoozedOnly: false,
       },
     };
 
@@ -377,8 +406,8 @@ describe('selectActiveWorkContext', function () {
         filterLabels: {
           Chalk: FILTER_STATUS.Active,
           backlog: FILTER_STATUS.Inverted,
+          snoozed: FILTER_STATUS.Inverted,
         },
-        snoozedOnly: false,
       },
     };
 
@@ -509,7 +538,7 @@ describe('selectActiveFilterLabels', function () {
     expect(result).toEqual([]);
   });
 
-  it('should return active filter labels while excluding inverted and Unlabeled filters', function () {
+  it('should return active filter labels while excluding inverted and virtual filters', function () {
     const state = {
       workspace: {
         filterLabels: {
@@ -517,6 +546,7 @@ describe('selectActiveFilterLabels', function () {
           urgent: FILTER_STATUS.Active,
           backlog: FILTER_STATUS.Inverted,
           Unlabeled: FILTER_STATUS.Active,
+          snoozed: FILTER_STATUS.Active,
         },
       },
     };

--- a/ui/js/src/selectors.test.ts.snap.android
+++ b/ui/js/src/selectors.test.ts.snap.android
@@ -79,7 +79,7 @@ exports[`selectFilteredTodos should filter out todos which have any inverted fil
 ]
 `;
 
-exports[`selectFilteredTodos should filter out todos with snoozed_until set to a future time 1`] = `
+exports[`selectFilteredTodos should filter out todos with snoozed_until set to a future time when snoozed is inverted 1`] = `
 [
   {
     "description": "normal todo",
@@ -103,7 +103,7 @@ exports[`selectFilteredTodos should filter todos missing any labels even when un
 ]
 `;
 
-exports[`selectFilteredTodos should include todos with snoozed_until set to a past time 1`] = `
+exports[`selectFilteredTodos should include todos with snoozed_until set to a past time when snoozed is inverted 1`] = `
 [
   {
     "description": "expired snooze todo",

--- a/ui/js/src/selectors.ts
+++ b/ui/js/src/selectors.ts
@@ -8,6 +8,10 @@ import {
 } from './redux/types';
 import { workContexts } from './redux/workspaceSlice';
 
+// Virtual labels are computed from todo data rather than real Label rows
+// (see 'Unlabeled' === todo.labels.length === 0, 'snoozed' === todo.snoozed_until > now)
+const VIRTUAL_LABELS = ['Unlabeled', 'snoozed'];
+
 const selectEditTodoId = (state: RootState) => state.workspace.editTodoId;
 const selectFilterLabels = (state: RootState) => state.workspace.filterLabels;
 const selectLabelTodoId = (state: RootState) => state.workspace.labelTodoId;
@@ -15,7 +19,6 @@ const selectShortcutOperations = (state: RootState) =>
   state.shortcuts.operations;
 const selectShowCompletedTodos = (state: RootState) =>
   state.workspace.showCompletedTodos;
-const selectSnoozedOnly = (state: RootState) => state.workspace.snoozedOnly;
 const selectTodoApiEntries = (state: RootState) => state.todosApi.entries;
 const selectLabelApiEntries = (state: RootState) => state.labelsApi.entries;
 
@@ -76,10 +79,13 @@ export const selectShortcuttedTodoEntries = createSelector(
 const performFilter = (
   labeledFlag: boolean,
   unlabeledFlag: boolean,
+  snoozedFlag: boolean,
+  unsnoozedFlag: boolean,
   activeFilters: string[],
   invertedFilters: string[],
   showCompletedTodos: boolean,
   preserveIds: number[],
+  now: Date,
   todo: Todo,
 ) => {
   if (preserveIds.includes(todo.id)) {
@@ -87,6 +93,14 @@ const performFilter = (
   }
 
   if (!showCompletedTodos && todo.completed) {
+    return false;
+  }
+
+  const isSnoozed = !!todo.snoozed_until && new Date(todo.snoozed_until) > now;
+  if (snoozedFlag && !isSnoozed) {
+    return false;
+  }
+  if (unsnoozedFlag && isSnoozed) {
     return false;
   }
 
@@ -108,7 +122,6 @@ export const selectFilteredTodos = createSelector(
     selectFilterLabels,
     selectLabelTodoId,
     selectShowCompletedTodos,
-    selectSnoozedOnly,
   ],
   (
     todoApiEntries,
@@ -116,36 +129,22 @@ export const selectFilteredTodos = createSelector(
     filterLabels,
     labelTodoId,
     showCompletedTodos,
-    snoozedOnly,
   ) => {
-    if (snoozedOnly) {
-      const now = new Date();
-      return todoApiEntries
-        .filter(
-          (todo) =>
-            todo.snoozed_until && new Date(todo.snoozed_until) > now,
-        )
-        .sort((a, b) => {
-          const aTime = new Date(a.snoozed_until as string).getTime();
-          const bTime = new Date(b.snoozed_until as string).getTime();
-          return aTime - bTime;
-        });
-    }
-
     // TODO (jordan) optimize w/ set intersection?
     const labeledFlag = filterLabels['Unlabeled'] === FILTER_STATUS.Inverted;
     const unlabeledFlag = filterLabels['Unlabeled'] === FILTER_STATUS.Active;
+    const snoozedFlag = filterLabels['snoozed'] === FILTER_STATUS.Active;
+    const unsnoozedFlag = filterLabels['snoozed'] === FILTER_STATUS.Inverted;
 
-    // Filter down to active filters excluding 'Unlabeled'
+    // Filter down to active/inverted filters excluding virtual labels
     const activeFilters = Object.keys(filterLabels).filter(
       (labelKey) =>
-        labelKey !== 'Unlabeled' &&
+        !VIRTUAL_LABELS.includes(labelKey) &&
         filterLabels[labelKey] === FILTER_STATUS.Active,
     );
-    // Filter down to inverted filters excluding 'Unlabeled'
     const invertedFilters = Object.keys(filterLabels).filter(
       (labelKey) =>
-        labelKey !== 'Unlabeled' &&
+        !VIRTUAL_LABELS.includes(labelKey) &&
         filterLabels[labelKey] === FILTER_STATUS.Inverted,
     );
 
@@ -163,35 +162,41 @@ export const selectFilteredTodos = createSelector(
     }
 
     const now = new Date();
-    return todoApiEntries
-      .filter((todo) => {
-        if (
-          !preserveIds.includes(todo.id) &&
-          todo.snoozed_until &&
-          new Date(todo.snoozed_until) > now
-        ) {
-          return false;
-        }
-        return performFilter(
-          labeledFlag,
-          unlabeledFlag,
-          activeFilters,
-          invertedFilters,
-          showCompletedTodos,
-          preserveIds,
-          todo,
-        );
+    const filteredTodos = todoApiEntries.filter((todo) =>
+      performFilter(
+        labeledFlag,
+        unlabeledFlag,
+        snoozedFlag,
+        unsnoozedFlag,
+        activeFilters,
+        invertedFilters,
+        showCompletedTodos,
+        preserveIds,
+        now,
+        todo,
+      ),
+    );
+
+    // In the Snoozed view, show what's expiring soonest first
+    if (snoozedFlag) {
+      return filteredTodos.sort((a, b) => {
+        const aTime = new Date(a.snoozed_until as string).getTime();
+        const bTime = new Date(b.snoozed_until as string).getTime();
+        return aTime - bTime;
       });
+    }
+
+    return filteredTodos;
   },
 );
 
 export const selectActiveFilterLabels = createSelector(
   [selectFilterLabels],
   (filterLabels) => {
-    // Extract active filters excluding 'Unlabeled' (which is virtual)
+    // Extract active filters excluding virtual labels
     return Object.keys(filterLabels).filter(
       (labelKey) =>
-        labelKey !== 'Unlabeled' &&
+        !VIRTUAL_LABELS.includes(labelKey) &&
         filterLabels[labelKey] === FILTER_STATUS.Active,
     );
   },
@@ -216,11 +221,8 @@ export const selectSelectedPickerLabels = createSelector(
 );
 
 export const selectActiveWorkContext = createSelector(
-  [selectFilterLabels, selectSnoozedOnly],
-  (filterLabels, snoozedOnly) => {
-    if (snoozedOnly) {
-      return 'snoozed';
-    }
+  [selectFilterLabels],
+  (filterLabels) => {
     return Object.keys(workContexts).find((workContext) => {
       const labels = workContexts[workContext].labels;
       const labelKeys = Object.keys(labels);


### PR DESCRIPTION
## Summary
- Fold `snoozed` into `filterLabels` as a virtual label (computed from `todo.snoozed_until`), matching how `Unlabeled` already works, instead of the separate `snoozedOnly` boolean with duplicated filtering branches.
- Add a `withDefaultInversions()` helper so every non-Inbox work context defaults to `backlog: Inverted, snoozed: Inverted`; Inbox explicitly gets `snoozed: Inverted` only (stays backlog-inclusive).
- Snoozed now composes with real label filters (e.g. a todo can be both snoozed and labeled "urgent" and show correctly in each view) instead of wiping `filterLabels` when selected.
- Regenerate Storybook snapshots for `App`, `SnoozeMenu`, `TodoItem`, `TodoList`, `WorkContextFilter`

## Test plan
- [x] `make test` (build+push, server tests, ui lint/typecheck/jest/storybook, tests lint) — all green
- [x] New test proving a todo can match both the Snoozed filter and a real label filter simultaneously
- [x] Updated `workspaceSlice`, `selectors`, `todosApiSlice` tests for the new virtual-label shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)