### PR TITLE
Fix offline-created todo visibility and cross-tab duplicate flush

### DIFF
--- a/ui/js/src/App.tsx
+++ b/ui/js/src/App.tsx
@@ -7,6 +7,7 @@ import OfflineBanner from './components/OfflineBanner';
 import TodoList from './components/TodoList';
 import { useAppDispatch, useAppSelector } from './hooks/hooks';
 import { useNetworkMonitor } from './hooks/useNetworkMonitor';
+import { useOfflineQueueSync } from './hooks/useOfflineQueueSync';
 import { flushOfflineQueue } from './redux/reducers';
 
 interface Style {
@@ -30,6 +31,7 @@ const styles = StyleSheet.create<Style>({
 
 const App: React.FC = function () {
   useNetworkMonitor();
+  useOfflineQueueSync();
   const dispatch = useAppDispatch();
   const loggedIn = useAppSelector((state) => state.workspace.loggedIn);
   const isOnline = useAppSelector((state) => state.network.isOnline);

--- a/ui/js/src/hooks/useOfflineQueueSync.ts
+++ b/ui/js/src/hooks/useOfflineQueueSync.ts
@@ -1,0 +1,2 @@
+// Native has a single app instance, so there's no other tab to sync with.
+export function useOfflineQueueSync() {}

--- a/ui/js/src/hooks/useOfflineQueueSync.web.test.ts
+++ b/ui/js/src/hooks/useOfflineQueueSync.web.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react-hooks';
+import offlineQueueSlice from '../redux/offlineQueueSlice';
+import { useOfflineQueueSync } from './useOfflineQueueSync.web';
+
+const mockDispatch = jest.fn();
+jest.mock('./hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}));
+
+function dispatchStorageEvent(key: string | null, newValue: string | null) {
+  window.dispatchEvent(
+    new StorageEvent('storage', { key: key ?? undefined, newValue }),
+  );
+}
+
+describe('useOfflineQueueSync', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should replace the queue when another tab updates the persisted offline queue', () => {
+    renderHook(() => useOfflineQueueSync());
+
+    const pendingOps = [{ type: 'update', payload: { id: 1 } }];
+    dispatchStorageEvent(
+      'persist:offlineQueue',
+      JSON.stringify({ pendingOps: JSON.stringify(pendingOps) }),
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      offlineQueueSlice.actions.replaceQueue(pendingOps),
+    );
+  });
+
+  it('should replace with an empty queue when another tab flushes to empty', () => {
+    renderHook(() => useOfflineQueueSync());
+
+    dispatchStorageEvent(
+      'persist:offlineQueue',
+      JSON.stringify({ pendingOps: JSON.stringify([]) }),
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      offlineQueueSlice.actions.replaceQueue([]),
+    );
+  });
+
+  it('should ignore storage events for unrelated keys', () => {
+    renderHook(() => useOfflineQueueSync());
+
+    dispatchStorageEvent('persist:todosApi', JSON.stringify({}));
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('should ignore storage clear events (newValue is null)', () => {
+    renderHook(() => useOfflineQueueSync());
+
+    dispatchStorageEvent('persist:offlineQueue', null);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('should not throw and should not dispatch on malformed storage values', () => {
+    renderHook(() => useOfflineQueueSync());
+
+    expect(() =>
+      dispatchStorageEvent('persist:offlineQueue', 'not-json'),
+    ).not.toThrow();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('should remove the storage listener on unmount', () => {
+    const { unmount } = renderHook(() => useOfflineQueueSync());
+    unmount();
+
+    const pendingOps = [{ type: 'update', payload: { id: 1 } }];
+    dispatchStorageEvent(
+      'persist:offlineQueue',
+      JSON.stringify({ pendingOps: JSON.stringify(pendingOps) }),
+    );
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/ui/js/src/hooks/useOfflineQueueSync.web.ts
+++ b/ui/js/src/hooks/useOfflineQueueSync.web.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import offlineQueueSlice from '../redux/offlineQueueSlice';
+import { OfflineOperation } from '../redux/types';
+import { useAppDispatch } from './hooks';
+
+const OFFLINE_QUEUE_STORAGE_KEY = 'persist:offlineQueue';
+
+// redux-persist stores each slice as a JSON string of an object whose values
+// are themselves JSON strings (see createPersistoid's per-key `serialize`),
+// so decoding requires unwrapping two layers of JSON.
+function parsePendingOps(rawValue: string): OfflineOperation[] {
+  const outer = JSON.parse(rawValue) as { pendingOps?: string };
+  return outer.pendingOps ? JSON.parse(outer.pendingOps) : [];
+}
+
+// Keeps this tab's offline queue in sync with other tabs' writes to the
+// shared persisted queue, so a tab doesn't resend an op another tab already
+// flushed. Paired with the navigator.locks usage in flushOfflineQueue.
+export function useOfflineQueueSync() {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== OFFLINE_QUEUE_STORAGE_KEY || event.newValue === null) {
+        return;
+      }
+
+      try {
+        const pendingOps = parsePendingOps(event.newValue);
+        dispatch(offlineQueueSlice.actions.replaceQueue(pendingOps));
+      } catch (error) {
+        console.warn('Failed to sync offline queue across tabs', error);
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, [dispatch]);
+}

--- a/ui/js/src/redux/offlineQueueSlice.test.ts
+++ b/ui/js/src/redux/offlineQueueSlice.test.ts
@@ -1,7 +1,8 @@
 import offlineQueueSlice from './offlineQueueSlice';
 import { OfflineOperation } from './types';
 
-const { enqueueOp, dequeueOpByIndex, clearQueue } = offlineQueueSlice.actions;
+const { enqueueOp, dequeueOpByIndex, clearQueue, replaceQueue } =
+  offlineQueueSlice.actions;
 
 describe('offlineQueueSlice reducer', function () {
   it('should initialise with empty pendingOps', function () {
@@ -66,6 +67,27 @@ describe('offlineQueueSlice reducer', function () {
         dequeueOpByIndex(1),
       );
       expect(state.pendingOps).toEqual([op1]);
+    });
+  });
+
+  describe('replaceQueue', function () {
+    it('should replace pendingOps with the given ops', function () {
+      const op1: OfflineOperation = { type: 'update', payload: { id: 1 } };
+      const op2: OfflineOperation = { type: 'update', payload: { id: 2 } };
+      const state = offlineQueueSlice.reducer(
+        { pendingOps: [op1] },
+        replaceQueue([op2]),
+      );
+      expect(state.pendingOps).toEqual([op2]);
+    });
+
+    it('should replace pendingOps with an empty array', function () {
+      const op1: OfflineOperation = { type: 'update', payload: { id: 1 } };
+      const state = offlineQueueSlice.reducer(
+        { pendingOps: [op1] },
+        replaceQueue([]),
+      );
+      expect(state.pendingOps).toEqual([]);
     });
   });
 

--- a/ui/js/src/redux/offlineQueueSlice.test.ts
+++ b/ui/js/src/redux/offlineQueueSlice.test.ts
@@ -38,7 +38,7 @@ describe('offlineQueueSlice reducer', function () {
     it('should append a create op', function () {
       const op: OfflineOperation = {
         type: 'create',
-        payload: { description: 'new todo', labels: ['work'] },
+        payload: { tempId: -1, description: 'new todo', labels: ['work'] },
       };
       const state = offlineQueueSlice.reducer(
         { pendingOps: [] },

--- a/ui/js/src/redux/offlineQueueSlice.ts
+++ b/ui/js/src/redux/offlineQueueSlice.ts
@@ -22,6 +22,11 @@ const offlineQueueSlice = createSlice({
     clearQueue: (state) => {
       state.pendingOps = [];
     },
+    // Resyncs this tab's queue with another tab's persisted write, e.g. after
+    // that tab flushed the queue while this tab held a stale in-memory copy.
+    replaceQueue: (state, action: PayloadAction<OfflineOperation[]>) => {
+      state.pendingOps = action.payload;
+    },
   },
 });
 

--- a/ui/js/src/redux/reducers.test.ts
+++ b/ui/js/src/redux/reducers.test.ts
@@ -416,6 +416,46 @@ describe('createTodo', function () {
     ]);
   });
 
+  it('should optimistically show the todo immediately, even when offline', async function () {
+    fetchMock.postOnce(getTodosApi(), {
+      throws: new TypeError('Network error'),
+    });
+
+    const store = setupStore();
+    await store.dispatch(createTodo('new todo'));
+
+    expect(store.getState().shortcuts.operations).toEqual([
+      {
+        type: 'CREATE_TODO',
+        payload: expect.objectContaining({
+          description: 'new todo',
+          labels: [],
+        }),
+        generation: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('should optimistically show the todo immediately when online too', async function () {
+    fetchMock.postOnce(getTodosApi(), {
+      body: { id: 99, description: 'new todo', labels: [] },
+    });
+
+    const store = setupStore();
+    await store.dispatch(createTodo('new todo'));
+
+    expect(store.getState().shortcuts.operations).toEqual([
+      {
+        type: 'CREATE_TODO',
+        payload: expect.objectContaining({
+          description: 'new todo',
+          labels: [],
+        }),
+        generation: expect.any(Number),
+      },
+    ]);
+  });
+
   it('should NOT enqueue when API rejected with non-TypeError (HTTP error)', async function () {
     fetchMock.postOnce(getTodosApi(), { status: 500 });
 

--- a/ui/js/src/redux/reducers.test.ts
+++ b/ui/js/src/redux/reducers.test.ts
@@ -412,11 +412,17 @@ describe('createTodo', function () {
     await store.dispatch(createTodo('new todo'));
 
     expect(store.getState().offlineQueue.pendingOps).toEqual([
-      { type: 'create', payload: { description: 'new todo', labels: [] } },
+      {
+        type: 'create',
+        payload: expect.objectContaining({
+          description: 'new todo',
+          labels: [],
+        }),
+      },
     ]);
   });
 
-  it('should optimistically show the todo immediately, even when offline', async function () {
+  it('should optimistically show the todo immediately, and keep showing it while queued offline', async function () {
     fetchMock.postOnce(getTodosApi(), {
       throws: new TypeError('Network error'),
     });
@@ -436,14 +442,15 @@ describe('createTodo', function () {
     ]);
   });
 
-  it('should optimistically show the todo immediately when online too', async function () {
+  it('should optimistically show the todo immediately, then clear the placeholder once the real todo is created', async function () {
     fetchMock.postOnce(getTodosApi(), {
       body: { id: 99, description: 'new todo', labels: [] },
     });
 
     const store = setupStore();
-    await store.dispatch(createTodo('new todo'));
+    const dispatchPromise = store.dispatch(createTodo('new todo'));
 
+    // Placeholder is visible synchronously, before the API call resolves
     expect(store.getState().shortcuts.operations).toEqual([
       {
         type: 'CREATE_TODO',
@@ -454,6 +461,21 @@ describe('createTodo', function () {
         generation: expect.any(Number),
       },
     ]);
+
+    await dispatchPromise;
+
+    // Once the real todo exists in todosApi.entries, the placeholder must be
+    // gone too, otherwise both would render as separate, duplicate todos.
+    expect(store.getState().shortcuts.operations).toEqual([]);
+  });
+
+  it('should clear the placeholder when the create permanently fails (non-TypeError)', async function () {
+    fetchMock.postOnce(getTodosApi(), { status: 500 });
+
+    const store = setupStore();
+    await store.dispatch(createTodo('new todo'));
+
+    expect(store.getState().shortcuts.operations).toEqual([]);
   });
 
   it('should NOT enqueue when API rejected with non-TypeError (HTTP error)', async function () {
@@ -571,6 +593,39 @@ describe('flushOfflineQueue', function () {
     await store.dispatch(flushOfflineQueue());
 
     expect(store.getState().notifications.notificationQueue).toEqual([]);
+  });
+
+  it('should clear the CREATE_TODO placeholder once a queued create is flushed successfully', async function () {
+    fetchMock.postOnce(getTodosApi(), {
+      body: { id: 99, description: 'new todo', labels: [] },
+    });
+    fetchMock.getOnce(getTodosApi(), {
+      body: [{ id: 99, description: 'new todo', labels: [] }],
+    });
+
+    const store = setupStore({
+      offlineQueue: {
+        pendingOps: [
+          {
+            type: 'create',
+            payload: { tempId: -1, description: 'new todo', labels: [] },
+          },
+        ],
+      },
+      shortcuts: {
+        operations: [
+          {
+            type: 'CREATE_TODO',
+            payload: { tempId: -1, description: 'new todo', labels: [] },
+            generation: 0,
+          },
+        ],
+        latestGeneration: 0,
+      },
+    });
+    await store.dispatch(flushOfflineQueue());
+
+    expect(store.getState().shortcuts.operations).toEqual([]);
   });
 
   it('should process update ops and show success notification', async function () {

--- a/ui/js/src/redux/reducers.test.ts
+++ b/ui/js/src/redux/reducers.test.ts
@@ -682,4 +682,50 @@ describe('flushOfflineQueue', function () {
   });
 });
 
+describe('flushOfflineQueue with navigator.locks', function () {
+  const originalLocks: unknown = (navigator as unknown as { locks?: unknown })
+    .locks;
+
+  afterEach(function () {
+    fetchMock.restore();
+    Object.defineProperty(navigator, 'locks', {
+      value: originalLocks,
+      configurable: true,
+    });
+  });
+
+  it('should serialize the flush via navigator.locks.request when available', async function () {
+    const request = jest.fn((_name: string, callback: () => Promise<void>) =>
+      callback(),
+    );
+    Object.defineProperty(navigator, 'locks', {
+      value: { request },
+      configurable: true,
+    });
+
+    fetchMock.patchOnce(`${getTodosApi()}1/`, {
+      body: { id: 1, description: 'ok' },
+    });
+    fetchMock.getOnce(getTodosApi(), { body: [] });
+
+    const store = setupStore({
+      offlineQueue: {
+        pendingOps: [{ type: 'update', payload: { id: 1, description: 'ok' } }],
+      },
+      todosApi: {
+        entries: [{ id: 1, description: 'old' }],
+        pendingCreates: [],
+        pendingArchives: [],
+      },
+    });
+    await store.dispatch(flushOfflineQueue());
+
+    expect(request).toHaveBeenCalledWith(
+      'chalk-offline-queue-flush',
+      expect.any(Function),
+    );
+    expect(store.getState().offlineQueue.pendingOps).toEqual([]);
+  });
+});
+
 export {};

--- a/ui/js/src/redux/reducers.ts
+++ b/ui/js/src/redux/reducers.ts
@@ -245,54 +245,67 @@ export const createTodo =
   };
 
 export const flushOfflineQueue = (): AppThunk => async (dispatch, getState) => {
-  const pendingOps = getState().offlineQueue.pendingOps;
-  if (pendingOps.length === 0) {
-    return;
-  }
+  const doFlush = async () => {
+    // Re-read pendingOps now that the lock (if any) is held: another tab may
+    // have already flushed and synced this tab's queue down to empty via
+    // useOfflineQueueSync while we were waiting.
+    const pendingOps = getState().offlineQueue.pendingOps;
+    if (pendingOps.length === 0) {
+      return;
+    }
 
-  dispatch(offlineQueueSlice.actions.clearQueue());
+    dispatch(offlineQueueSlice.actions.clearQueue());
 
-  const failedOps: OfflineOperation[] = [];
-  for (const op of pendingOps) {
-    let result;
-    if (op.type === 'create') {
-      result = await dispatch(createTodoApi(op.payload.description));
-      if (createTodoApi.rejected.match(result)) {
-        failedOps.push(op);
-      }
-    } else if (op.type === 'update') {
-      result = await dispatch(updateTodoApi(op.payload));
-      if (updateTodoApi.rejected.match(result)) {
-        failedOps.push(op);
-      }
-    } else if (op.type === 'move') {
-      result = await dispatch(moveTodoApi(op.payload));
-      if (moveTodoApi.rejected.match(result)) {
-        failedOps.push(op);
+    const failedOps: OfflineOperation[] = [];
+    for (const op of pendingOps) {
+      let result;
+      if (op.type === 'create') {
+        result = await dispatch(createTodoApi(op.payload.description));
+        if (createTodoApi.rejected.match(result)) {
+          failedOps.push(op);
+        }
+      } else if (op.type === 'update') {
+        result = await dispatch(updateTodoApi(op.payload));
+        if (updateTodoApi.rejected.match(result)) {
+          failedOps.push(op);
+        }
+      } else if (op.type === 'move') {
+        result = await dispatch(moveTodoApi(op.payload));
+        if (moveTodoApi.rejected.match(result)) {
+          failedOps.push(op);
+        }
       }
     }
-  }
 
-  for (const op of failedOps) {
-    dispatch(offlineQueueSlice.actions.enqueueOp(op));
-  }
+    for (const op of failedOps) {
+      dispatch(offlineQueueSlice.actions.enqueueOp(op));
+    }
 
-  await dispatch(listTodosApi());
+    await dispatch(listTodosApi());
 
-  if (failedOps.length === 0) {
-    dispatch(
-      notificationsSlice.actions.addNotification({
-        text: 'Changes synced',
-        type: 'default',
-      }),
-    );
+    if (failedOps.length === 0) {
+      dispatch(
+        notificationsSlice.actions.addNotification({
+          text: 'Changes synced',
+          type: 'default',
+        }),
+      );
+    } else {
+      dispatch(
+        notificationsSlice.actions.addNotification({
+          text: 'Some changes could not be synced',
+          type: 'default',
+        }),
+      );
+    }
+  };
+
+  // Web only: multiple browser tabs share the same persisted queue, so
+  // serialize flushes across tabs to avoid sending the same op twice.
+  if (typeof navigator !== 'undefined' && 'locks' in navigator) {
+    await navigator.locks.request('chalk-offline-queue-flush', doFlush);
   } else {
-    dispatch(
-      notificationsSlice.actions.addNotification({
-        text: 'Some changes could not be synced',
-        type: 'default',
-      }),
-    );
+    await doFlush();
   }
 };
 

--- a/ui/js/src/redux/reducers.ts
+++ b/ui/js/src/redux/reducers.ts
@@ -27,6 +27,10 @@ import { workspaceSlice } from './workspaceSlice';
 
 type AppThunk = ThunkAction<void, RootState, unknown, Action<string>>;
 
+// Negative, monotonically-decrementing IDs for optimistic create placeholders,
+// distinguishing them from real (positive) server-assigned todo IDs.
+let nextTempTodoId = -1;
+
 export const updateTodo =
   (todoPatch: TodoPatch): AppThunk =>
   async (dispatch, getState) => {
@@ -55,9 +59,15 @@ export const updateTodo =
     }
 
     const result = await dispatch(updateTodoApi(todoPatch));
-    if (updateTodoApi.rejected.match(result) && result.error.name === 'TypeError') {
+    if (
+      updateTodoApi.rejected.match(result) &&
+      result.error.name === 'TypeError'
+    ) {
       dispatch(
-        offlineQueueSlice.actions.enqueueOp({ type: 'update', payload: todoPatch }),
+        offlineQueueSlice.actions.enqueueOp({
+          type: 'update',
+          payload: todoPatch,
+        }),
       );
     }
   };
@@ -101,9 +111,15 @@ export const moveTodo =
     dispatch(shortcutSlice.actions.addMoveTodoOperation(operation));
 
     const result = await dispatch(moveTodoApi(operation));
-    if (moveTodoApi.rejected.match(result) && result.error.name === 'TypeError') {
+    if (
+      moveTodoApi.rejected.match(result) &&
+      result.error.name === 'TypeError'
+    ) {
       dispatch(
-        offlineQueueSlice.actions.enqueueOp({ type: 'move', payload: operation }),
+        offlineQueueSlice.actions.enqueueOp({
+          type: 'move',
+          payload: operation,
+        }),
       );
     }
   };
@@ -207,8 +223,18 @@ export const createTodo =
   (todoTitle: string): AppThunk =>
   async (dispatch, getState) => {
     const activeLabels = selectActiveFilterLabels(getState());
+    dispatch(
+      shortcutSlice.actions.addCreateTodoOperation({
+        tempId: nextTempTodoId--,
+        description: todoTitle,
+        labels: activeLabels,
+      }),
+    );
     const result = await dispatch(createTodoApi(todoTitle));
-    if (createTodoApi.rejected.match(result) && result.error.name === 'TypeError') {
+    if (
+      createTodoApi.rejected.match(result) &&
+      result.error.name === 'TypeError'
+    ) {
       dispatch(
         offlineQueueSlice.actions.enqueueOp({
           type: 'create',
@@ -293,7 +319,10 @@ function makePersistReducer<S, A extends Action>(
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const storage = require('./persistStorage').default;
   // persistReducer returns a compatible reducer type
-  return persistReducer({ key, storage, blacklist }, reducer) as unknown as Reducer<S, A>;
+  return persistReducer(
+    { key, storage, blacklist },
+    reducer,
+  ) as unknown as Reducer<S, A>;
 }
 
 const offlineQueueReducer =
@@ -303,7 +332,10 @@ const offlineQueueReducer =
 
 const todosApiReducer =
   process.env.NODE_ENV !== 'test'
-    ? makePersistReducer('todosApi', todosApiSlice.reducer, ['loading', 'initialLoad'])
+    ? makePersistReducer('todosApi', todosApiSlice.reducer, [
+        'loading',
+        'initialLoad',
+      ])
     : todosApiSlice.reducer;
 
 export const rootReducerConfig = {

--- a/ui/js/src/redux/reducers.ts
+++ b/ui/js/src/redux/reducers.ts
@@ -223,9 +223,10 @@ export const createTodo =
   (todoTitle: string): AppThunk =>
   async (dispatch, getState) => {
     const activeLabels = selectActiveFilterLabels(getState());
+    const tempId = nextTempTodoId--;
     dispatch(
       shortcutSlice.actions.addCreateTodoOperation({
-        tempId: nextTempTodoId--,
+        tempId,
         description: todoTitle,
         labels: activeLabels,
       }),
@@ -238,9 +239,13 @@ export const createTodo =
       dispatch(
         offlineQueueSlice.actions.enqueueOp({
           type: 'create',
-          payload: { description: todoTitle, labels: activeLabels },
+          payload: { tempId, description: todoTitle, labels: activeLabels },
         }),
       );
+    } else {
+      // Either the real todo now exists in todosApi.entries, or the create
+      // permanently failed — either way the placeholder is no longer needed.
+      dispatch(shortcutSlice.actions.removeCreateTodoOperation(tempId));
     }
   };
 
@@ -263,6 +268,10 @@ export const flushOfflineQueue = (): AppThunk => async (dispatch, getState) => {
         result = await dispatch(createTodoApi(op.payload.description));
         if (createTodoApi.rejected.match(result)) {
           failedOps.push(op);
+        } else {
+          dispatch(
+            shortcutSlice.actions.removeCreateTodoOperation(op.payload.tempId),
+          );
         }
       } else if (op.type === 'update') {
         result = await dispatch(updateTodoApi(op.payload));

--- a/ui/js/src/redux/shortcutSlice.test.ts
+++ b/ui/js/src/redux/shortcutSlice.test.ts
@@ -9,6 +9,56 @@ describe('shortcut reducer', function () {
     });
   });
 
+  describe('shortcuts/removeCreateTodoOperation', function () {
+    it('should remove the CREATE_TODO op matching the given tempId', function () {
+      const result = shortcutSlice.reducer(
+        {
+          operations: [
+            {
+              type: 'CREATE_TODO',
+              payload: { tempId: -1, description: 'a', labels: [] },
+              generation: 0,
+            },
+            {
+              type: 'CREATE_TODO',
+              payload: { tempId: -2, description: 'b', labels: [] },
+              generation: 0,
+            },
+          ],
+        },
+        {
+          type: 'shortcuts/removeCreateTodoOperation',
+          payload: -1,
+        },
+      );
+      expect(result).toEqual({
+        operations: [
+          {
+            type: 'CREATE_TODO',
+            payload: { tempId: -2, description: 'b', labels: [] },
+            generation: 0,
+          },
+        ],
+      });
+    });
+
+    it('should leave non-CREATE_TODO ops untouched', function () {
+      const editOp = {
+        type: 'EDIT_TODO',
+        payload: { id: 1, description: 'edited' },
+        generation: 0,
+      };
+      const result = shortcutSlice.reducer(
+        { operations: [editOp] },
+        {
+          type: 'shortcuts/removeCreateTodoOperation',
+          payload: -1,
+        },
+      );
+      expect(result).toEqual({ operations: [editOp] });
+    });
+  });
+
   describe('shortcuts/clearOperationsUpThroughGeneration', function () {
     it('should toggle a new label to active', function () {
       const result = shortcutSlice.reducer(

--- a/ui/js/src/redux/shortcutSlice.ts
+++ b/ui/js/src/redux/shortcutSlice.ts
@@ -1,6 +1,6 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { ShortcutState } from './types';
+import { CreateTodoOperation, ShortcutState } from './types';
 
 // Store operations for optimistic updates
 const initialState: ShortcutState = {
@@ -31,6 +31,19 @@ export default createSlice({
         payload: action.payload,
         generation: state.latestGeneration,
       });
+    },
+    // Removes a CREATE_TODO placeholder as soon as its real create call
+    // resolves, rather than waiting for the next listTodos poll cycle to
+    // clear it by generation — otherwise the placeholder and the newly
+    // created (real) todo are both visible for up to 10s.
+    removeCreateTodoOperation: (state, action: PayloadAction<number>) => {
+      state.operations = state.operations.filter(
+        (op) =>
+          !(
+            op.type === 'CREATE_TODO' &&
+            (op.payload as CreateTodoOperation).tempId === action.payload
+          ),
+      );
     },
     incrementGenerations: (state) => {
       state.latestGeneration = state.latestGeneration + 1;

--- a/ui/js/src/redux/shortcutSlice.ts
+++ b/ui/js/src/redux/shortcutSlice.ts
@@ -25,6 +25,13 @@ export default createSlice({
         generation: state.latestGeneration,
       });
     },
+    addCreateTodoOperation: (state, action) => {
+      state.operations.push({
+        type: 'CREATE_TODO',
+        payload: action.payload,
+        generation: state.latestGeneration,
+      });
+    },
     incrementGenerations: (state) => {
       state.latestGeneration = state.latestGeneration + 1;
     },

--- a/ui/js/src/redux/types.ts
+++ b/ui/js/src/redux/types.ts
@@ -108,6 +108,6 @@ export interface ShortcutState {
 }
 
 export type OfflineOperation =
-  | { type: 'create'; payload: { description: string; labels: string[] } }
+  | { type: 'create'; payload: CreateTodoOperation }
   | { type: 'update'; payload: TodoPatch }
   | { type: 'move'; payload: MoveTodoOperation };

--- a/ui/js/src/redux/types.ts
+++ b/ui/js/src/redux/types.ts
@@ -90,9 +90,15 @@ export interface MoveTodoOperation {
   todo_id: number;
 }
 
+export interface CreateTodoOperation {
+  tempId: number;
+  description: string;
+  labels: string[];
+}
+
 export interface ShortcutOperation {
-  type: 'EDIT_TODO' | 'MOVE_TODO';
-  payload: TodoPatch | MoveTodoOperation;
+  type: 'EDIT_TODO' | 'MOVE_TODO' | 'CREATE_TODO';
+  payload: TodoPatch | MoveTodoOperation | CreateTodoOperation;
   generation: number;
 }
 

--- a/ui/js/src/selectors.test.ts
+++ b/ui/js/src/selectors.test.ts
@@ -524,6 +524,71 @@ describe('selectShortcuttedTodoEntries', function () {
     const result = selectShortcuttedTodoEntries(state);
     expect(result).toStrictEqual([]);
   });
+
+  it('should optimistically show newly created todos before any completed todos', function () {
+    const state = {
+      shortcuts: {
+        operations: [
+          {
+            type: 'CREATE_TODO',
+            payload: {
+              tempId: -1,
+              description: 'New Todo',
+              labels: ['work'],
+            },
+          },
+        ],
+      },
+      todosApi: {
+        entries: [
+          todoEntries[0],
+          { ...todoEntries[1], completed: true },
+          todoEntries[2],
+        ],
+      },
+    };
+
+    const result = selectShortcuttedTodoEntries(state);
+    expect(result).toEqual([
+      todoEntries[0],
+      expect.objectContaining({
+        id: -1,
+        archived: false,
+        completed: false,
+        description: 'New Todo',
+        labels: ['work'],
+        version: 0,
+      }),
+      { ...todoEntries[1], completed: true },
+      todoEntries[2],
+    ]);
+  });
+
+  it('should optimistically append a newly created todo when no todos are completed', function () {
+    const state = {
+      shortcuts: {
+        operations: [
+          {
+            type: 'CREATE_TODO',
+            payload: {
+              tempId: -1,
+              description: 'New Todo',
+              labels: [],
+            },
+          },
+        ],
+      },
+      todosApi: {
+        entries: todoEntries,
+      },
+    };
+
+    const result = selectShortcuttedTodoEntries(state);
+    expect(result).toEqual([
+      ...todoEntries,
+      expect.objectContaining({ id: -1, description: 'New Todo' }),
+    ]);
+  });
 });
 
 describe('selectActiveFilterLabels', function () {

--- a/ui/js/src/selectors.ts
+++ b/ui/js/src/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from './redux/store';
 import {
+  CreateTodoOperation,
   FILTER_STATUS,
   MoveTodoOperation,
   Todo,
@@ -68,6 +69,27 @@ export const selectShortcuttedTodoEntries = createSelector(
           relativeIdx++;
         }
         shortcuttedTodoEntries.splice(relativeIdx, 0, todo);
+      } else if (op.type === 'CREATE_TODO') {
+        const createOp = op.payload as CreateTodoOperation;
+        const placeholderTodo: Todo = {
+          id: createOp.tempId,
+          archived: false,
+          completed: false,
+          created_at: Date.now(),
+          description: createOp.description,
+          labels: createOp.labels,
+          version: 0,
+        };
+
+        // Keep completed todos at the bottom, matching processTodos in todosApiSlice
+        const firstCompletedIdx = shortcuttedTodoEntries.findIndex(
+          (todo) => todo.completed,
+        );
+        if (firstCompletedIdx === -1) {
+          shortcuttedTodoEntries.push(placeholderTodo);
+        } else {
+          shortcuttedTodoEntries.splice(firstCompletedIdx, 0, placeholderTodo);
+        }
       } else {
         throw new Error(`Unexpected shortcut operation type: ${op.type}`);
       }


### PR DESCRIPTION
## Summary
Fixes both bugs reported in the review comment on #349:

- New todos entered while offline never appeared in the UI until reconnecting — `createTodo` had no optimistic local update (unlike `updateTodo`/`moveTodo`), so it stayed invisible until the offline queue flushed and a server response came back. It now gets the same optimistic-shortcut treatment: a `CREATE_TODO` op renders a placeholder immediately, cleared once the real todo arrives from the server.
- Reconnecting with a second browser tab open sent the same queued op twice, creating a duplicate todo — each tab has its own in-memory Redux store hydrated once from `localStorage`, with no coordination between tabs. `flushOfflineQueue` now serializes across tabs via `navigator.locks` (web only), and a new `useOfflineQueueSync` hook keeps each tab's in-memory queue synced with another tab's writes via the `storage` event, so a tab that acquires the lock second sees the queue another tab already flushed instead of resending it.

## Test plan
- [x] `make test` (server + UI unit tests, Storybook tests, lint) passes
- [x] New/updated unit tests: `selectors.test.ts` (CREATE_TODO optimistic placeholder), `reducers.test.ts` (create-op optimistic dispatch, `navigator.locks` flush serialization), `offlineQueueSlice.test.ts` (`replaceQueue`), `useOfflineQueueSync.web.test.ts` (cross-tab storage sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)