### PR TITLE
Fix redux-persist noop storage warning + offline todo disappearing

### DIFF
--- a/ui/js/src/redux/persistStorage.test.ts
+++ b/ui/js/src/redux/persistStorage.test.ts
@@ -1,0 +1,57 @@
+describe('persistStorage', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.dontMock('react-native');
+    jest.dontMock('redux-persist/lib/storage');
+    jest.dontMock('@react-native-async-storage/async-storage');
+  });
+
+  it('uses redux-persist web storage on web without evaluating native storage', () => {
+    const webDefault = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+    const nativeModuleEvaluated = jest.fn();
+    jest.doMock('react-native', () => ({ Platform: { OS: 'web' } }));
+    jest.doMock('redux-persist/lib/storage', () => ({ default: webDefault }));
+    jest.doMock('@react-native-async-storage/async-storage', () => {
+      nativeModuleEvaluated();
+      return { default: {} };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const storage = require('./persistStorage').default;
+
+    expect(storage).toBe(webDefault);
+    expect(nativeModuleEvaluated).not.toHaveBeenCalled();
+  });
+
+  it('uses native async-storage on native without evaluating redux-persist web storage', () => {
+    const nativeDefault = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+    const webModuleEvaluated = jest.fn();
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.doMock('redux-persist/lib/storage', () => {
+      webModuleEvaluated();
+      return { default: {} };
+    });
+    jest.doMock('@react-native-async-storage/async-storage', () => ({
+      default: nativeDefault,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const storage = require('./persistStorage').default;
+
+    expect(storage).toBe(nativeDefault);
+    expect(webModuleEvaluated).not.toHaveBeenCalled();
+  });
+});
+
+export {};

--- a/ui/js/src/redux/persistStorage.ts
+++ b/ui/js/src/redux/persistStorage.ts
@@ -1,11 +1,15 @@
 import { Platform } from 'react-native';
 import type { Storage } from 'redux-persist/es/types';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const webStorage: Storage = require('redux-persist/lib/storage').default;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const nativeStorage: Storage = require('@react-native-async-storage/async-storage').default;
-
-const storage: Storage = Platform.OS === 'web' ? webStorage : nativeStorage;
+// Only require the storage backend for the current platform: `redux-persist`'s
+// web storage module runs a synchronous `window.localStorage` feature check at
+// import time, which logs "redux-persist failed to create sync storage" if
+// merely imported on native (no `localStorage` global), even when unused.
+const storage: Storage =
+  Platform.OS === 'web'
+    ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('redux-persist/lib/storage').default
+    : // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('@react-native-async-storage/async-storage').default;
 
 export default storage;

--- a/ui/js/src/redux/reducers.test.ts
+++ b/ui/js/src/redux/reducers.test.ts
@@ -345,6 +345,33 @@ describe('listTodos', function () {
     // Verify we made the server request
     expect(fetchMock).toBeDone();
   });
+
+  it('should not clear shortcut operations when the request fails', async function () {
+    fetchMock.getOnce(`${getTodosApi()}`, {
+      throws: new TypeError('Failed to fetch'),
+    });
+
+    const store = setupStore({
+      shortcuts: {
+        latestGeneration: 0,
+        operations: [
+          {
+            type: 'CREATE_TODO',
+            payload: { tempId: -1, description: 'offline todo', labels: [] },
+            generation: 0,
+          },
+        ],
+      },
+    });
+    await store.dispatch(listTodos());
+
+    // Generation still increments even on failure
+    expect(store.getState().shortcuts.latestGeneration).toEqual(1);
+
+    // The optimistic op is preserved since the fetch that would confirm it
+    // (and replace it with the real todo) never succeeded
+    expect(store.getState().shortcuts.operations.length).toEqual(1);
+  });
 });
 
 describe('moveTodo', function () {

--- a/ui/js/src/redux/reducers.ts
+++ b/ui/js/src/redux/reducers.ts
@@ -126,13 +126,22 @@ export const moveTodo =
 
 export const listTodos = (): AppThunk => async (dispatch, getState) => {
   const latestGeneration = getState().shortcuts.latestGeneration;
-  await Promise.all([
+  const [, listResult] = await Promise.all([
     dispatch(shortcutSlice.actions.incrementGenerations()),
     dispatch(listTodosApi()),
   ]);
-  return dispatch(
-    shortcutSlice.actions.clearOperationsUpThroughGeneration(latestGeneration),
-  );
+  // Only clear optimistic shortcut ops once we've confirmed the server
+  // reflects them. If listTodosApi failed (e.g. offline), todosApi.entries
+  // is left untouched, so clearing the shortcuts here would make optimistic
+  // updates (like an offline-created todo) disappear with nothing to
+  // replace them.
+  if (listTodosApi.fulfilled.match(listResult)) {
+    dispatch(
+      shortcutSlice.actions.clearOperationsUpThroughGeneration(
+        latestGeneration,
+      ),
+    );
+  }
 };
 
 // Used to exchange login token for session cookie in mobile login flow


### PR DESCRIPTION
## Summary
- Fixes the PR #349 review comment: running the dev app logs `redux-persist failed to create sync storage. falling back to noop storage.` at the `const webStorage` line in `persistStorage.ts`.
  - Root cause: `persistStorage.ts` unconditionally required **both** `redux-persist/lib/storage` and `@react-native-async-storage/async-storage` before selecting one via `Platform.OS`. `redux-persist/lib/storage` runs a synchronous `window.localStorage` feature check at import time, so merely requiring it on native (no `localStorage` global) logs the warning and falls back to noop storage, even though that backend is never used on native.
  - Fix: only `require()` the storage backend needed for the current platform.
- Fixes a regression found while verifying the offline-created-todo fix: a todo created while offline showed up immediately, but disappeared again after ~10s (the next `listTodos` poll).
  - Root cause: `listTodos()` (`reducers.ts`) unconditionally cleared shortcut operations (the optimistic-update mechanism) up through the pre-poll generation after every poll cycle, even when `listTodosApi` rejected (e.g. offline). `todosApi.entries` is left untouched on rejection, so clearing the optimistic `CREATE_TODO` shortcut discarded the placeholder with nothing from the server to replace it.
  - Fix: only clear shortcut operations once `listTodosApi` actually succeeds.

## Test plan
- [x] `persistStorage.test.ts`: asserts each platform branch resolves to the correct storage and never evaluates the other platform's module.
- [x] `reducers.test.ts`: new `listTodos` case asserting shortcut operations are preserved when the list request fails.
- [x] `make test` passes (server + UI unit/storybook tests, lint).